### PR TITLE
Change install instructions for LibSodium

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -28,7 +28,7 @@ REQUIRED INSTALLATION DEPENDENCIES
 
 GET DEBIAN / UBUNTU INSTALL DEPENDENCIES:
 0. sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install python 
-1. sudo apt-get install libsodium-dev -y
+1. sudo apt-get install git libtool automake && git clone https://github.com/jedisct1/libsodium && cd libsodium && ./autogen.sh && ./configure && make && make check && sudo make install
 2. sudo apt-get install python-pip -y && sudo pip install numpy --upgrade
 3. (optional) sudo apt-get install python-matplotlib -y
 


### PR DESCRIPTION
When I ran `sudo apt-get install libsodium-dev` it didn't find it, so I changed the instructions to build the program from scratch in step 1 of installing the dependencies.  It works great, although it would be good for someone else just to make sure it's good.  It will help the less tech-savy people install this program from source.