### PR TITLE
initial blacklist edits

### DIFF
--- a/lib/bitcoin/__init__.py
+++ b/lib/bitcoin/__init__.py
@@ -4,4 +4,5 @@ from bitcoin.main import *
 from bitcoin.transaction import *
 from bitcoin.deterministic import *
 from bitcoin.bci import *
+from bitcoin.podle import *
 

--- a/lib/bitcoin/podle.py
+++ b/lib/bitcoin/podle.py
@@ -1,0 +1,100 @@
+#Proof Of Discrete Logarithm Equivalence
+#For algorithm steps, see https://gist.github.com/AdamISZ/9cbba5e9408d23813ca8
+import secp256k1
+import os
+from py2specials import *
+from py3specials import *
+
+N = 115792089237316195423570985008687907852837564279074904382605163141518161494337
+dummy_pub = secp256k1.PublicKey()
+
+'''NUMS - an alternate basepoint on the secp256k1 curve
+For background (taken from https://github.com/AdamISZ/ConfidentialTransactionsDoc/blob/master/essayonCT.pdf)
+>>> import bitcoin as btc
+>>> import os
+>>>H_x = int(sha256(btc.encode_pubkey(btc.G,'hex').decode('hex')).hexdigest(),16)
+>>> H_x
+	36444060476547731421425013472121489344383018981262552973668657287772036414144L 
+>>> H_y = pow(int(H_x*H_x*H_x + 7), int((btc.P+1)//4), int(btc.P))
+>>> H_y
+	93254584761608041185240733468443117438813272608612929589951789286136240436011L
+>>> H = (H_x, H_y)
+'''
+J_raw = '0350929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0'
+J = secp256k1.PublicKey(safe_from_hex(J_raw), raw=True)
+        
+def getP2(priv):
+    priv_raw = priv.private_key
+    return J.tweak_mul(priv_raw)
+       
+def generate_podle(priv):
+    '''Given a raw private key, in hex format,
+    construct a commitment sha256(P2), which is
+    the hash of the value x*J, where x is the private
+    key as a raw scalar, and J is a NUMS alternative
+    basepoint on the Elliptic Curve. Also construct
+    a signature (s,e) of Schnorr type, which will serve
+    as a zero knowledge proof that the private key of P2
+    is the same as the private key of P (=x*G).
+    Signature is constructed as:
+    s = k + x*e
+    where k is a standard 32 byte nonce and:
+    e = sha256(k*G || k*J || P || P2)
+    '''
+    if len(priv)==66 and priv[-2:]=='01':
+        priv = priv[:-2]
+    priv = secp256k1.PrivateKey(safe_from_hex(priv))
+    P = priv.pubkey
+    k = os.urandom(32)
+    KG = secp256k1.PrivateKey(k).pubkey
+    KJ = J.tweak_mul(k)
+    P2 = getP2(priv)
+    commitment = hashlib.sha256(P2.serialize()).digest()
+    e = hashlib.sha256(''.join([x.serialize() for x in [KG, KJ, P, P2]])).digest()
+    k_int = decode(k, 256)
+    priv_int = decode(priv.private_key, 256)
+    e_int = decode(e, 256)
+    sig_int = (k_int + priv_int*e_int) % N
+    sig = encode(sig_int, 256, minlen=32)
+    P2hex, chex, shex, ehex = [safe_hexlify(x) for x in [P2.serialize(),commitment, sig, e]]
+    return {'P2':P2hex, 'commit': chex, 'sig': shex, 'e':ehex}
+
+def verify_podle(Pser, P2ser, sig, e, commitment):
+    Pser, P2ser, sig, e, commitment = [safe_from_hex(x) for x in [Pser, P2ser, sig, e, commitment]]
+    #check 1: Hash(P2ser) =?= commitment
+    if not hashlib.sha256(P2ser).digest() == commitment:
+        return False
+    sig_priv = secp256k1.PrivateKey(sig,raw=True)
+    sG = sig_priv.pubkey
+    sJ = J.tweak_mul(sig)
+    P = secp256k1.PublicKey(Pser, raw=True)
+    P2 = secp256k1.PublicKey(P2ser, raw=True)
+    e_int = decode(e, 256)
+    minus_e = encode(-e_int % N, 256, minlen=32)
+    minus_e_P = P.tweak_mul(minus_e)
+    minus_e_P2 = P2.tweak_mul(minus_e)
+    KG = dummy_pub.combine([sG.public_key, minus_e_P.public_key])
+    KJ = dummy_pub.combine([sJ.public_key, minus_e_P2.public_key])
+    KGser = secp256k1.PublicKey(KG).serialize()
+    KJser = secp256k1.PublicKey(KJ).serialize()
+    #check 2: e =?= H(K_G || K_J || P || P2)
+    e_check = hashlib.sha256(KGser + KJser + Pser + P2ser).digest()
+    if not e_check == e:
+        return False
+    return True
+
+if __name__ == '__main__':
+    
+    for i in range(10000):
+        priv = os.urandom(32)
+        Priv = secp256k1.PrivateKey(priv)
+        Pser = safe_hexlify(Priv.pubkey.serialize())
+        podle_sig = generate_podle(safe_hexlify(priv))
+        P2ser, s, e, commitment = (podle_sig['P2'], podle_sig['sig'], 
+                                   podle_sig['e'], podle_sig['commit'])
+        if not verify_podle(Pser, P2ser, s, e, commitment):
+            print 'failed to verify'
+    
+    
+    
+    

--- a/lib/bitcoin/secp256k1.py
+++ b/lib/bitcoin/secp256k1.py
@@ -1,6 +1,6 @@
 import os
 import hashlib
-
+import binascii
 from _libsecp256k1 import ffi, lib
 import _noncefunc
 

--- a/lib/message_channel.py
+++ b/lib/message_channel.py
@@ -59,8 +59,8 @@ class MessageChannel(object):
 		self.on_pubkey = on_pubkey
 		self.on_ioauth = on_ioauth
 		self.on_sig = on_sig
-	def fill_orders(self, nickoid_dict, cj_amount, taker_pubkey): pass
-	def send_auth(self, nick, pubkey, sig): pass
+	def fill_orders(self, nickoid_dict, cj_amount, taker_pubkey, commitment=None): pass
+	def send_auth(self, nick, pubkey, sig, utxo=None, P2=None, s=None, e=None): pass
 	def send_tx(self, nick_list, txhex): pass
 	def push_tx(self, nick, txhex): pass
 

--- a/test/blacklist-test.py
+++ b/test/blacklist-test.py
@@ -1,0 +1,105 @@
+import sys
+import os, time
+data_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, os.path.join(data_dir, 'lib'))
+import subprocess
+import unittest
+import common
+import commontest
+from blockchaininterface import *
+import bitcoin as btc
+import binascii
+	
+class BlackListPassTests(unittest.TestCase):
+    '''This test case intends to simulate
+    a single join with a single counterparty. In that sense,
+    it's not realistic, because nobody (should) do joins with only 1 maker, 
+    but this test has the virtue of being the simplest possible thing 
+    that JoinMarket can do. '''
+    def setUp(self):
+        #create 2 new random wallets.
+        #put 10 coins into the first receive address
+        #to allow that bot to start.
+	self.wallets = commontest.make_wallets(2, 
+	            wallet_structures=[[1,0,0,0,0],[1,0,0,0,0]], mean_amt=10)
+        
+        
+    def blacklist_run(self, n, m, fake):
+	if os.path.isfile('logs/blacklist'):
+	    os.remove('logs/blacklist')
+        #start yield generator with wallet1
+	yigen_proc = commontest.local_command(['python','yield-generator.py', 
+	                            str(self.wallets[0]['seed'])],bg=True)
+	
+	#A significant delay is needed to wait for the yield generator to sync its wallet
+	time.sleep(10)
+	
+	#run a single sendpayment call with wallet2
+	amt = n*100000000 #in satoshis
+	dest_address = btc.privkey_to_address(os.urandom(32), from_hex=False, magicbyte=common.get_p2pk_vbyte())
+	try:
+	    for i in range(m):
+		sp_proc = commontest.local_command(['python','sendpayment.py','--yes','-N','1', self.wallets[1]['seed'],\
+	                                       str(amt), dest_address])
+	except subprocess.CalledProcessError, e:
+	    if yigen_proc:
+		yigen_proc.terminate()
+	    print e.returncode
+	    print e.message
+	    raise
+
+	if yigen_proc:
+	    yigen_proc.terminate()
+	if not fake:
+	    received = common.bc_interface.get_received_by_addr([dest_address], None)['data'][0]['balance']
+	    if received != amt*m:
+		common.debug('received was: '+str(received)+ ' but amount was: '+str(amt))
+		return False
+	#check sanity in blacklist
+	with open('logs/blacklist','rb') as f:
+	    blacklist_lines = f.readlines()
+	if not fake:
+	    required_bl_lines = m
+	    bl_count = 1
+	else:
+	    required_bl_lines = 1
+	    bl_count = m
+	if len(blacklist_lines) != required_bl_lines:
+	    common.debug('wrong number of blacklist lines: '+str(len(blacklist_lines)))
+	    return False
+	
+	for bl in blacklist_lines:
+	    if len(bl.split(',')[0].strip()) != 64:
+		common.debug('malformed utxo: '+str(len(bl.split(',')[0].strip())))
+		return False
+	    if int(bl.split(',')[1]) != bl_count:
+		common.debug('wrong blacklist count:'+str(bl.split(',')[1]))
+		return False
+	return True
+    	
+    def test_blacklist(self):
+        self.failUnless(self.blacklist_run(2, 2, False))
+	
+
+
+
+def main():
+    os.chdir(data_dir)
+    common.load_program_config()
+    unittest.main()
+
+if __name__ == '__main__':
+    #Big kludge, but there is currently no way to inject this code:
+    print """this test is to be run in two modes, first
+    with no changes, then second adding a 'return' in 
+    taker.CoinJoinTX.push() return (so it does nothing),
+    and further changing the third parameter to blacklist_run to 'True'
+    and the second parameter to '3' from '2'
+    In both cases the test should pass for success.
+    Also, WARNING! This test will delete your blacklist, better
+    not run it in a "real" repo or back it up.
+    """
+    raw_input("OK?")
+    main()
+    
+

--- a/test/regtest.py
+++ b/test/regtest.py
@@ -72,7 +72,7 @@ class Join2PTests(unittest.TestCase):
 	                            str(self.wallets[0]['seed'])],bg=True)
 	
 	#A significant delay is needed to wait for the yield generator to sync its wallet
-	time.sleep(30)
+	time.sleep(20)
 	
 	#run a single sendpayment call with wallet2
 	amt = n*100000000 #in satoshis
@@ -126,7 +126,7 @@ class JoinNPTests(unittest.TestCase):
 	    yigen_procs.append(ygp)
 	
 	#A significant delay is needed to wait for the yield generators to sync 
-	time.sleep(60)
+	time.sleep(20)
 	
 	#run a single sendpayment call
 	amt = 100000000 #in satoshis

--- a/test/wallet-test.py
+++ b/test/wallet-test.py
@@ -18,6 +18,8 @@ class TestWalletCreation(unittest.TestCase):
 	#testing a variety of passwords
 	self.failUnless(self.run_generate('abc123'))
 	self.failUnless(self.run_generate('dddddddddddddddddddddddddddddddddddddddddddd'))
+	#silly length
+	self.failUnless(self.run_generate('abc8'*1000))
 	#null password is accepted
 	self.failUnless(self.run_generate(''))
 	#binary password is accepted; good luck with that!
@@ -31,7 +33,7 @@ class TestWalletCreation(unittest.TestCase):
 	    expected = ['Enter wallet encryption passphrase:',
 		        'Reenter wallet encryption passphrase:',
 		        'Input wallet file name']
-	    testlog = open('test/testlog-'+pwd, 'wb')
+	    testlog = open('test/testlog-'+pwd[:25], 'wb')
 	    p = pexpect.spawn('python wallet-tool.py generate', logfile=testlog)
 	    commontest.interact(p, test_in, expected)
 	    p.expect('saved to')
@@ -39,7 +41,7 @@ class TestWalletCreation(unittest.TestCase):
 	    p.close()
 	    testlog.close()
 	    #anything to check in the log?
-	    with open(os.path.join('test','testlog-'+pwd)) as f:
+	    with open(os.path.join('test','testlog-'+pwd[:25])) as f:
 		print f.read()
 	    if p.exitstatus != 0:
 		print 'failed due to exit status: '+str(p.exitstatus)
@@ -50,7 +52,8 @@ class TestWalletCreation(unittest.TestCase):
 		print 'failed due to wallet missing'
 		return False
 	    os.remove('wallets/testwallet.json')
-	except:
+	except Exception as e:
+	    print 'try except failed with error: '+repr(e)
 	    return False
 	return True	
 

--- a/yield-generator.py
+++ b/yield-generator.py
@@ -113,10 +113,7 @@ class YieldGenerator(Maker):
 		return ([], [neworders[0]])
 
 	def on_tx_confirmed(self, cjorder, confirmations, txid):
-		if cjorder.cj_addr in self.tx_unconfirm_timestamp:
-			confirm_time = int(time.time()) - self.tx_unconfirm_timestamp[cjorder.cj_addr]
-		else:
-			confirm_time = 0
+		confirm_time = int(time.time()) - self.tx_unconfirm_timestamp[cjorder.cj_addr]
 		timestamp = datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")
 		self.log_statement([timestamp, cjorder.cj_amount, len(cjorder.utxos),
 			sum([av['value'] for av in cjorder.utxos.values()]), cjorder.real_cjfee,


### PR DESCRIPTION
DO NOT MERGE.

(needs rebasing anyway :) )

Idea: every new btc utxo used for signing by taker in !auth is appended to a 'blacklist' file with a counter. the counter is incremented when the utxo is reused. If the counter exceeds the value in "LIMIT","taker_utxo_retries", the !auth is rejected (so no maker utxos are sent across).

There are as I see it two big issues with this (at least).

The first, most important: we currently only send input btc *pubkey* in the !auth message, not a utxo. So, the taker can send any old pubkey, not necessarily corresponding to a real utxo. In the current model (see the last paragraph of encryption_protocol.txt), the validity of this pubkey is checked only before sending across our transaction signatures, so if a fake pubkey is used, we don't send signatures, but we do send utxos (in !iouath) from maker to taker.

This PR changes that, which means a version change in Joinmarket, so is very disruptive. The taker sends also a utxo along with the pubkey (the latter could be ditched). the maker calls query_utxo_set on it, and ensures that it's a valid utxo. It could easily (I would definitely add this) check the coin age/confirmations of that utxo also. This allows what's described in the first paragraph above.

The other big issue with this is that it makes takers very fragile to disruptive makers. If *any* maker decides not to cooperate (or just fails), this "uses up" that utxo and the taker cannot use it more than 3 times. *If* we were to apply this model I think we would also want to add code to allow the taker to choose a different one of his utxos in the next attempt.

The last point to make, I guess, is that this is fairly weak, depending on if we decided to include coin age restriction and coin amount restriction.