### PR TITLE
add confirmation-spendability knob for bitcoind-rpc

### DIFF
--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -135,6 +135,18 @@ merge_algorithm = default
 # as our default. Note that for clients not using a local blockchain
 # instance, we retrieve an estimate from the API at blockcypher.com, currently.
 tx_fees = 3
+# the range of confirmations passed to the `listunspent` bitcoind RPC call
+# 1st value is the inclusive minimum, defaults to one confirmation
+# 2nd value is the exclusive maximum, defaults to most-positive-bignum (Google Me!)
+# leave it unset to defer to bitcoind's default values, ie [1, 9999999]
+#listunspent = []
+# unless you have a specific reason, eg:
+#  spend from unconfirmed transactions:  listunspent_args = [0]
+# display only unconfirmed transactions: listunspent_args = [0, 1]
+# defend against small reorganizations:  listunspent_args = [3]
+#   who is at risk of reorganization?:   listunspent_args = [0, 2]
+# NB: using 0 for the 1st value with scripts other than wallet-tool could cause
+# spends from unconfirmed inputs, which may then get malleated or double-spent!
 """
 
 

--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -138,15 +138,16 @@ tx_fees = 3
 # the range of confirmations passed to the `listunspent` bitcoind RPC call
 # 1st value is the inclusive minimum, defaults to one confirmation
 # 2nd value is the exclusive maximum, defaults to most-positive-bignum (Google Me!)
-# leave it unset to defer to bitcoind's default values, ie [1, 9999999]
-#listunspent = []
-# unless you have a specific reason, eg:
+# leaving it unset or empty defers to bitcoind's default values, ie [1, 9999999]
+#listunspent_args = []
+# that's what you should do, unless you have a specific reason, eg:
 #  spend from unconfirmed transactions:  listunspent_args = [0]
 # display only unconfirmed transactions: listunspent_args = [0, 1]
 # defend against small reorganizations:  listunspent_args = [3]
 #   who is at risk of reorganization?:   listunspent_args = [0, 2]
 # NB: using 0 for the 1st value with scripts other than wallet-tool could cause
 # spends from unconfirmed inputs, which may then get malleated or double-spent!
+# other counterparties are likely to reject unconfirmed inputs... don't do it.
 """
 
 

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -99,6 +99,10 @@ else:
                     extend_mixdepth=not maxmixdepth_configured,
                     storepassword=(method == 'importprivkey'))
     if method not in noscan_methods:
+        # if nothing was configured, we override bitcoind's options so that
+        # unconfirmed balance is included in the wallet display by default
+        if 'listunspent_args' not in jm_single().config.options('POLICY'):
+            jm_single().config.set('POLICY','listunspent_args', '[0]')
         jm_single().bc_interface.sync_wallet(wallet)
 
 if method == 'display' or method == 'displayall' or method == 'summary':


### PR DESCRIPTION
This addresses #39 but does not solve it for blockr users.

When using a full node, `wallet-tool.py` will display unconfirmed balances by default, but other scripts won't actually spend them unless that behavior is manually configured.