### PR TITLE
Restructure for_change HD branch as {in,ex}ternal

### DIFF
--- a/joinmarket/maker.py
+++ b/joinmarket/maker.py
@@ -343,8 +343,8 @@ class Maker(CoinJoinerPeer):
 		"""
 
         order = [o for o in self.orderlist if o['oid'] == oid][0]
-        cj_addr = self.wallet.get_receive_addr(order['mixdepth'] + 1)
-        change_addr = self.wallet.get_change_addr(order['mixdepth'])
+        cj_addr = self.wallet.get_internal_addr(order['mixdepth'] + 1)
+        change_addr = self.wallet.get_internal_addr(order['mixdepth'])
         return [order['utxo']], cj_addr, change_addr
 
     def get_next_oid(self):

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -58,7 +58,19 @@ class AbstractWallet(object):
     def get_utxos_by_mixdepth(self):
         return None
 
-    def get_change_addr(self, mixing_depth):
+    def get_external_addr(self, mixing_depth):
+        """
+        Return an address suitable for external distribution, including funding
+        the wallet from other sources, or receiving payments or donations.
+        JoinMarket will never generate these addresses for internal use.
+        """
+        return None
+
+    def get_internal_addr(self, mixing_depth):
+        """
+        Return an address for internal usage, as change addresses and when
+        participating in transactions initiated by other parties.
+        """
         return None
 
     def update_cache_index(self):
@@ -224,10 +236,10 @@ class Wallet(AbstractWallet):
                             [addr, bc_interface.get_wallet_name(self), False])
         return addr
 
-    def get_receive_addr(self, mixing_depth):
+    def get_external_addr(self, mixing_depth):
         return self.get_new_addr(mixing_depth, 0)
 
-    def get_change_addr(self, mixing_depth):
+    def get_internal_addr(self, mixing_depth):
         return self.get_new_addr(mixing_depth, 1)
 
     def get_key_from_addr(self, addr):
@@ -311,7 +323,7 @@ class BitcoinCoreWallet(AbstractWallet):
                 'value': int(Decimal(str(u['amount'])) * Decimal('1e8'))}
         return result
 
-    def get_change_addr(self, mixing_depth):
+    def get_internal_addr(self, mixing_depth):
         return jm_single().bc_interface.rpc('getrawchangeaddress', [])
 
     @staticmethod

--- a/patientsendpayment.py
+++ b/patientsendpayment.py
@@ -52,7 +52,7 @@ class TakerThread(threading.Thread):
         self.tmaker.start_cj(
                 self.tmaker.wallet, self.tmaker.amount, orders, utxos,
                 self.tmaker.destaddr,
-                self.tmaker.wallet.get_change_addr(self.tmaker.mixdepth),
+                self.tmaker.wallet.get_internal_addr(self.tmaker.mixdepth),
                 self.tmaker.txfee, self.finishcallback)
 
 
@@ -98,7 +98,7 @@ class PatientSendPayment(Maker, Taker):
         # its possible this bot will end up paying to the destaddr more than it
         # intended
         utxos = self.wallet.select_utxos(self.mixdepth, amount)
-        return utxos, self.destaddr, self.wallet.get_change_addr(self.mixdepth)
+        return utxos, self.destaddr, self.wallet.get_internal_addr(self.mixdepth)
 
     def on_tx_unconfirmed(self, cjorder, balance, removed_utxos):
         self.amount -= cjorder.cj_amount

--- a/sendpayment.py
+++ b/sendpayment.py
@@ -112,7 +112,7 @@ class PaymentThread(threading.Thread):
             utxos = self.taker.wallet.select_utxos(self.taker.mixdepth, 
                 total_amount+2*self.taker.txfee*self.taker.makercount)
             cjamount = self.taker.amount
-            change_addr = self.taker.wallet.get_change_addr(self.taker.mixdepth)
+            change_addr = self.taker.wallet.get_internal_addr(self.taker.mixdepth)
             choose_orders_recover = self.sendpayment_choose_orders
 
         self.taker.start_cj(self.taker.wallet, cjamount, orders, utxos,

--- a/test/commontest.py
+++ b/test/commontest.py
@@ -75,7 +75,7 @@ def make_wallets(n, wallet_structures=None, mean_amt=1, sdev_amt=0, start_index=
                 amt = mean_amt - sdev_amt / 2.0 + deviation
                 if amt < 0: amt = 0.001
                 jm_single().bc_interface.grab_coins(
-                    wallets[i+start_index]['wallet'].get_receive_addr(j), amt)
+                    wallets[i+start_index]['wallet'].get_external_addr(j), amt)
     return wallets
 
 

--- a/test/fee-estimation.py
+++ b/test/fee-estimation.py
@@ -77,7 +77,7 @@ class FeeEstimateTests(unittest.TestCase):
         #having created the bad wallet, add lots of utxos to 
         #the same mixdepth
         print 'creating a crazy amount of utxos in one wallet...'
-        r_addr = self.wallets[2]['wallet'].get_receive_addr(0)
+        r_addr = self.wallets[2]['wallet'].get_external_addr(0)
         for i in range(60):
             jm_single().bc_interface.grab_coins(r_addr,0.02)
             time.sleep(1)

--- a/test/tumbler-test.py
+++ b/test/tumbler-test.py
@@ -51,7 +51,7 @@ class TumblerTests(unittest.TestCase):
                     amt = base + random.random(
                     )  #average is 0.5 for tumbler, else 1.5
                     jm_single().bc_interface.grab_coins(
-                        w.get_receive_addr(j), amt)
+                        w.get_external_addr(j), amt)
 
     def run_tumble(self, amt):
         yigen_procs = []

--- a/tumbler.py
+++ b/tumbler.py
@@ -218,8 +218,8 @@ class TumblerThread(threading.Thread):
             if cj_amount < self.taker.options.mincjamount:
                 log.debug('cj amount too low, bringing up')
                 cj_amount = self.taker.options.mincjamount
-            change_addr = self.taker.wallet.get_change_addr(self.tx[
-                                                                'srcmixdepth'])
+            change_addr = self.taker.wallet.get_internal_addr(
+                self.tx['srcmixdepth'])
             log.debug('coinjoining ' + str(cj_amount) + ' satoshi')
             orders, total_cj_fee = self.tumbler_choose_orders(
                     cj_amount, self.tx['makercount'])
@@ -256,7 +256,7 @@ class TumblerThread(threading.Thread):
     def init_tx(self, tx, balance, sweep):
         destaddr = None
         if tx['destination'] == 'internal':
-            destaddr = self.taker.wallet.get_receive_addr(tx['srcmixdepth'] + 1)
+            destaddr = self.taker.wallet.get_internal_addr(tx['srcmixdepth'] + 1)
         elif tx['destination'] == 'addrask':
             jm_single().debug_silence = True
             while True:

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -26,8 +26,8 @@ import bitcoin as btc
 # using coins from different levels as inputs to the same tx is probably
 # detrimental to privacy
 
-# m/0/n/0/k kth receive address, for mixing depth n
-# m/0/n/1/k kth change address, for mixing depth n
+# m/0/n/0/k kth external address, for mixing depth n
+# m/0/n/1/k kth internal address, for mixing depth n
 
 description = (
     'Does useful little tasks involving your bip32 wallet. The '
@@ -112,7 +112,7 @@ if method == 'display' or method == 'displayall' or method == 'summary':
         cus_print('mixing depth %d m/0/%d/' % (m, m))
         balance_depth = 0
         for forchange in [0, 1]:
-            cus_print(' ' + ('receive' if forchange == 0 else 'change') +
+            cus_print(' ' + ('external' if forchange == 0 else 'internal') +
                       ' addresses m/0/%d/%d/' % (m, forchange))
 
             for k in range(wallet.index[m][forchange] + options.gaplimit):

--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -99,9 +99,9 @@ class YieldGenerator(Maker):
                 break
             mixdepth = (mixdepth - 1) % self.wallet.max_mix_depth
         # mixdepth is the chosen depth we'll be spending from
-        cj_addr = self.wallet.get_receive_addr((mixdepth + 1) %
-                                               self.wallet.max_mix_depth)
-        change_addr = self.wallet.get_change_addr(mixdepth)
+        cj_addr = self.wallet.get_internal_addr(
+            (mixdepth + 1) % self.wallet.max_mix_depth)
+        change_addr = self.wallet.get_internal_addr(mixdepth)
 
         utxos = self.wallet.select_utxos(mixdepth, amount)
         my_total_in = sum([va['value'] for va in utxos.values()])

--- a/yield-generator-deluxe.py
+++ b/yield-generator-deluxe.py
@@ -362,9 +362,9 @@ class YieldGenerator(Maker):
         log.debug('filling offer, mixdepth=' + str(mixdepth))
 
         # mixdepth is the chosen depth we'll be spending from
-        cj_addr = self.wallet.get_receive_addr((mixdepth + 1) %
-                                               self.wallet.max_mix_depth)
-        change_addr = self.wallet.get_change_addr(mixdepth)
+        cj_addr = self.wallet.get_internal_addr(
+            (mixdepth + 1) % self.wallet.max_mix_depth)
+        change_addr = self.wallet.get_internal_addr(mixdepth)
 
         utxos = self.wallet.select_utxos(mixdepth, amount)
         my_total_in = sum([va['value'] for va in utxos.values()])

--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -168,9 +168,9 @@ class YieldGenerator(Maker):
         log.debug('filling offer, mixdepth=' + str(mixdepth))
 
         # mixdepth is the chosen depth we'll be spending from
-        cj_addr = self.wallet.get_receive_addr((mixdepth + 1) %
-                                               self.wallet.max_mix_depth)
-        change_addr = self.wallet.get_change_addr(mixdepth)
+        cj_addr = self.wallet.get_internal_addr(
+            (mixdepth + 1) % self.wallet.max_mix_depth)
+        change_addr = self.wallet.get_internal_addr(mixdepth)
 
         utxos = self.wallet.select_utxos(mixdepth, amount)
         my_total_in = sum([va['value'] for va in utxos.values()])


### PR DESCRIPTION
Fixes #283

Note that this is MORE than a naming change: tumbler.py, maker.py,
and the yield-generator scrypts have been modified to use only the
internal branch, specifically to avoid reuse of receiving address.