### PR TITLE
Handle pushtx failures. Catch jsonrpcerror exception and retry for tu…

### DIFF
--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -18,7 +18,7 @@ import bitcoin as btc
 # This can be removed once CliJsonRpc is gone.
 import subprocess
 
-from joinmarket.jsonrpc import JsonRpcConnectionError
+from joinmarket.jsonrpc import JsonRpcConnectionError, JsonRpcError
 from joinmarket.configure import get_p2pk_vbyte, jm_single
 from joinmarket.support import get_log, chunks
 
@@ -646,9 +646,12 @@ class BitcoinCoreInterface(BlockchainInterface):
 
     def pushtx(self, txhex):
         try:
-            return self.rpc('sendrawtransaction', [txhex])
-        except JsonRpcConnectionError:
-            return None
+            txid = self.rpc('sendrawtransaction', [txhex])
+        except JsonRpcConnectionError as e:
+	    return (False, repr(e))
+        except JsonRpcError as e:
+	    return (False, str(e.code) + " " + str(e.message))
+        return (True, txid)
 
     def query_utxo_set(self, txout):
         if not isinstance(txout, list):

--- a/joinmarket/maker.py
+++ b/joinmarket/maker.py
@@ -257,9 +257,11 @@ class Maker(CoinJoinerPeer):
 
     def on_push_tx(self, nick, txhex):
         log.debug('received txhex from ' + nick + ' to push\n' + txhex)
-        txid = jm_single().bc_interface.pushtx(txhex)
-        log.debug('pushed tx ' + str(txid))
-        if txid is None:
+        pushed = jm_single().bc_interface.pushtx(txhex)
+        if pushed[0]:
+            log.debug('pushed tx ' + str(pushed[1]))
+        else:
+            log.debug('failed to push tx, reason: '+str(pushed[1]))
             self.msgchan.send_error(nick, 'Unable to push tx')
 
     def on_welcome(self):

--- a/joinmarket/taker.py
+++ b/joinmarket/taker.py
@@ -299,13 +299,16 @@ class CoinJoinTX(object):
         # TODO send to a random maker or push myself
         # TODO need to check whether the other party sent it
         # self.msgchan.push_tx(self.active_orders.keys()[0], txhex)
-        self.txid = jm_single().bc_interface.pushtx(tx)
-        if self.txid is None:
-            log.debug('unable to pushtx')
+        pushed = jm_single().bc_interface.pushtx(tx)
+        if pushed[0]:
+            self.txid = pushed[1]
+        else:
+            log.debug('unable to pushtx, reason: '+str(pushed[1]))
+        return pushed[0]
 
     def self_sign_and_push(self):
         self.self_sign()
-        self.push(self.latest_tx)
+        return self.push(self.latest_tx)
 
     def recover_from_nonrespondants(self):
         log.debug('nonresponding makers = ' + str(self.nonrespondants))

--- a/sendpayment.py
+++ b/sendpayment.py
@@ -122,8 +122,12 @@ class PaymentThread(threading.Thread):
 
     def finishcallback(self, coinjointx):
         if coinjointx.all_responded:
-            coinjointx.self_sign_and_push()
-            log.debug('created fully signed tx, ending')
+            pushed = coinjointx.self_sign_and_push()
+            if pushed:
+                log.debug('created fully signed tx, ending')
+            else:
+                #Error should be in log, will not retry.
+                log.debug('failed to push tx, ending.')
             self.taker.msgchan.shutdown()
             return
         self.ignored_makers += coinjointx.nonrespondants

--- a/tumbler.py
+++ b/tumbler.py
@@ -114,8 +114,12 @@ class TumblerThread(threading.Thread):
             jm_single().bc_interface.add_tx_notify(
                     coinjointx.latest_tx, self.unconfirm_callback,
                     self.confirm_callback, coinjointx.my_cj_addr)
-            self.taker.wallet.remove_old_utxos(coinjointx.latest_tx)
-            coinjointx.self_sign_and_push()
+            pushed = coinjointx.self_sign_and_push()
+            if pushed:
+                self.taker.wallet.remove_old_utxos(coinjointx.latest_tx)
+            else:
+                log.debug("Failed to push transaction, trying again.")
+                self.create_tx()
         else:
             self.ignored_makers += coinjointx.nonrespondants
             log.debug('recreating the tx, ignored_makers=' + str(


### PR DESCRIPTION
…mbler.

~~NOT READY TO MERGE.~~

Previously, pushtx caught the JsonRpcConnectionError, but not the JsonRpcError, which is thrown when, for example, the transaction contains a spent utxo (this was the situation that some users mentioned, I also saw it myself). Crashing on this exception is no big deal in the case of a sendpayment run, because we've finished at that point anyway, but for tumbler, it makes more sense to simply retry the transaction again. To address this, caught the exception and printed the error code to the debug log.

However, this is not ready to merge because there is something clunky about the tumbler restarting, that I'm not sure of the right way to deal with. See finish_callback edit: https://github.com/JoinMarket-Org/joinmarket/pull/369/files#diff-7dca4cc17829f93a2517b5a8dd3ef018L112

This doesn't seem right; add_tx_notify spins up a thread waiting for the walletnotify, and then pushtx() is called. We can restart the transaction if pushtx() fails, but this leaves the notify thread dangling (infinitely I think?). On the other hand, we (presumably?) cannot start the walletnotify thread *after* calling pushtx() because the unconfirm callback might get called too quicky? (I wasn't at all sure about this; if that's wrong, then that might be the right solution). As it is now, it could potentially keep creating new unwanted notify threads for transactions that were never pushed. Advice on the right way to do it?

Edit: the above has now been addressed; see the clarifications in the below comments.