### PR TITLE
fixes issues #106 and #358

### DIFF
--- a/yield-generator-deluxe.py
+++ b/yield-generator-deluxe.py
@@ -21,47 +21,57 @@ mix_levels = 5  # Careful! Only change this if you setup your wallet as such.
 nickname = random_nick()
 nickserv_password = ''
 
-#min_output_size = 15000 # only create change greater than this amount
-min_output_size = random.randrange(15000, 300000)  #random
-#min_output_size = jm_single().DUST_THRESHOLD # 546 satoshis
-
-#num_offers = 8 # number of offers to autogenerate
-num_offers = random.randrange(4, 7)  #random
-#num_offers = mix_levels
-
-#spread types
+#Spread Types
 # fibonacci- will gradually increase at the rate of the fibonacci sequence
 # evenly- will be evenly spaced 
 # random- random amounts between the high and the low
 # custom- use _custom to set it directly
 # bymixdepth- (for offers), make offer amounts equal to mixdepths
-# note, when using bymixdepth, set 'num_offers = mix_levels' above
+# note, when using bymixdepth, set 'num_offers = mix_levels'
 
 # min and max offer sizes
 offer_spread = 'fibonacci'  # fibonacci, evenly, random, custom, bymixdepth
-offer_low = None  # when None, min_output_size will be used
-offer_high = None  # when None, size of largest mix depth will be used
-#offer_high = random.randrange(2500000000, 3000000000)
+offer_low = None  # satoshis. when None, min_output_size will be used
+offer_high = None  # satoshis. when None, size of largest mix depth will be used
+#offer_low = random.randrange(21000000, 1e8)  #random
+#offer_high = random.randrange(150 * 1e8, 200 * 1e8)
 custom_offers = [
-    1, 1.5, 10, 100
-]  # in bitcoins, used when offer_spread is set to custom
+    1.01 * 1e8, 112345657, 1 * 1e8, 10 * 1e8, 100 * 1e8
+]  # used when offer_spread is set to custom
 
 # percent fees for mix levels.
 cjfee_spread = 'fibonacci'  # fibonacci, evenly, random, custom
-cjfee_low = random.uniform(0.0001, 0.001)
-cjfee_high = random.uniform(0.01, 0.015)
+cjfee_low = random.uniform(0.0004, 0.0005)
+cjfee_high = random.uniform(0.001, 0.01)
 custom_cjfees = [
-    0.011, 0.012, 0.013, 0.014, 0.015
-]  # from smallest to largest, used when cjfee_spread is set to custom
+    0.01, 0.0123, 0.013, 0.014, 0.015
+]  # used when cjfee_spread is set to custom
 
 txfee_spread = 'fibonacci'  # fibonacci, evenly, random, custom
-txfee_low = random.randrange(100, 300)
-txfee_high = random.randrange(4000, 6000)
+txfee_low = random.randrange(1, 100)
+txfee_high = random.randrange(3000, 5000)
 custom_txfees = [
-    300, 500, 800, 1000, 1200
+    250, 500, 1000, 2000, 5000
 ]  # used when txfee_spread is set to custom
 
-# You can overwrite the above autogenerate options for maximum customization
+# number of offers to autogenerate
+num_offers = random.randrange(6, 9)  # varied
+#num_offers = 8 
+#num_offers = mix_levels
+
+# only create change greater than this amount
+min_output_size = random.randrange(15000, 300000)  # varied
+#min_output_size = random.randrange(5e6, 21e6)  # varied
+#min_output_size = 15000 
+#min_output_size = jm_single().DUST_THRESHOLD # 546 satoshis
+
+# minimum revenue you require for a transaction (exact absorders for dust exempt)
+min_revenue = random.randrange(txfee_low, 12000)  # varied
+#min_revenue = txfee_low # break even
+#min_revenue = int(txfee_low * 1.5) # 50% net revenue
+#min_revenue = random.randrange(txfee_low, txfee_low * 3)
+
+# You can override the above autogenerate options for maximum customization
 override_offers = None  # comment this line if using below
 """
 override_offers = [
@@ -76,6 +86,19 @@ override_offers = [
 #END CONFIGURATION
 
 log = get_log()
+if offer_low:
+    log.debug('offer_low = ' + str(offer_low) + " (" + str(offer_low / 1e8) +
+              " btc)")
+if offer_high:
+    log.debug('offer_high = ' + str(offer_high) + " (" + str(offer_high / 1e8) +
+              " btc)")
+log.debug('cjfee_low = ' + str(cjfee_low))
+log.debug('cjfee_high = ' + str(cjfee_high))
+log.debug('txfee_low = ' + str(txfee_low))
+log.debug('txfee_high = ' + str(txfee_high))
+log.debug('min_output_size = ' + str(min_output_size) + " (" + str(
+    min_output_size / 1e8) + " btc)")
+log.debug('min_revenue = ' + str(min_revenue))
 
 
 def fib(n):
@@ -85,30 +108,26 @@ def fib(n):
     return a
 
 
-def fib_seq(low, high, num, for_offers=False):
-    if for_offers:
-        total = high - low
-    else:
-        total = high
-    num += 1  # because 1,1,2
-    fib_sec = total / fib(num)
+def fib_seq(low, high, num, upper_bound=False):
     x = []
-    if for_offers:
-        for y in range(2, num):
-            x.append(low + (fib_sec * fib(y)))
+    if upper_bound:
+        num += 1
     else:
         x.append(low)
-        for y in range(3, num):
-            x.append(fib_sec * fib(y))
+    fib_sec = high / decimal.Decimal(fib(num))
+    for y in range(2, num):
+        x.append(low + (fib_sec * fib(y)))
     x.append(high)
     return x
 
 
+# range function for decimals
 def drange(start, stop, step):
     r = start
     while r < stop:
         yield r
         r += step
+    yield stop
 
 
 class YieldGenerator(Maker):
@@ -144,14 +163,16 @@ class YieldGenerator(Maker):
     def create_my_orders(self):
         mix_balance = self.wallet.get_balance_by_mixdepth()
         log.debug('mix_balance = ' + str(mix_balance))
-        filtered_mix_balance = sorted(
+        log.debug('mix_btcance = ' + str([(x, y / 1e8)
+                                          for x, y in mix_balance.iteritems()]))
+        sorted_mix_balance = sorted(
             list(mix_balance.iteritems()),
             key=lambda a: a[1])  #sort by size
 
-        max_mixdepth_size = filtered_mix_balance[-1][1]
-        if max_mixdepth_size is 0:
-            print("ALERT: wallet empty")
-            sys.exit(0)
+        largest_mixdepth_size = sorted_mix_balance[-1][1]
+        if largest_mixdepth_size <= min_output_size:
+            print("ALERT: not enough funds available in wallet")
+            return []
 
         if override_offers:
             log.debug('override_offers = \n' + '\n'.join([str(
@@ -177,9 +198,10 @@ class YieldGenerator(Maker):
 
         offer_lowx = max(offer_low, min_output_size)
         if offer_high:
-            offer_highx = min(offer_high, max_mixdepth_size - min_output_size)
+            offer_highx = min(offer_high,
+                              largest_mixdepth_size - min_output_size)
         else:
-            offer_highx = filtered_mix_balance[-1][1] - min_output_size
+            offer_highx = largest_mixdepth_size - min_output_size
             # note, subtracting mix_output_size here to make minimum size change
             # todo, make an offer for exactly the max size with no change
 
@@ -188,25 +210,38 @@ class YieldGenerator(Maker):
             offer_levels = fib_seq(offer_lowx,
                                    offer_highx,
                                    num_offers,
-                                   for_offers=True)
+                                   upper_bound=True)
+            offer_levels = [int(round(x)) for x in offer_levels]
         elif offer_spread == 'evenly':
-            offer_levels = list(range(
-                ((offer_highx - offer_lowx) / num_offers), offer_highx,
-                (offer_highx - offer_lowx) / (num_offers - 1))) + [offer_highx]
+            first_upper_bound = (offer_highx - offer_lowx) / num_offers
+            offer_levels = list(range(first_upper_bound, offer_highx, (
+                offer_highx - first_upper_bound) / (num_offers - 1)))
+            offer_levels = offer_levels[0:(num_offers - 1)] + [offer_highx]
         elif offer_spread == 'random':
             offer_levels = sorted([random.randrange(offer_lowx, offer_highx)
                                    for n in range(num_offers - 1)] +
                                   [random.randrange(offer_highx - (
                                       offer_highx / num_offers), offer_highx)])
         elif offer_spread == 'bymixdepth':
-            offer_levels = [m[1]
-                            for m in filtered_mix_balance if m[1] < offer_highx
-                           ] + [offer_highx]  # already sorted by size above
+            offer_levels = []
+            for m in sorted_mix_balance:
+                if m[1] == 0:
+                    continue
+                elif m[1] <= offer_lowx:
+                    # todo, low mix balances get an absolute offer
+                    continue
+                elif m[1] > offer_highx:
+                    offer_levels += [offer_highx]
+                    break
+                else:
+                    offer_levels += [m[1]]
+            # note, offer_levels len can be less then num_offers here
         elif offer_spread == 'custom':
+            assert len(custom_offers) == num_offers
             offer_levels = [
-                int((decimal.Decimal(str(x)) * 100000000).quantize(0))
+                int((decimal.Decimal(str(x))).quantize(0))
                 for x in sorted(custom_offers)
-            ]  # convert btc to satoshi
+            ]
             if offer_levels[-1] > offer_highx:
                 log.debug(
                     'ALERT: Your custom offers exceeds you max offer size.')
@@ -218,19 +253,20 @@ class YieldGenerator(Maker):
             sys.exit(0)
 
         # CJFees
-        cjfee_lowx, cjfee_highx = decimal.Decimal(str(
-            cjfee_low)) / 100, decimal.Decimal(str(cjfee_high)) / 100
+        cjfee_lowx = decimal.Decimal(str(cjfee_low)) / 100
+        cjfee_highx = decimal.Decimal(str(cjfee_high)) / 100
         if cjfee_spread == 'fibonacci':
             cjfee_levels = fib_seq(cjfee_lowx, cjfee_highx, num_offers)
             cjfee_levels = ["%0.7f" % x for x in cjfee_levels]
         elif cjfee_spread == 'evenly':
-            cjfee_levels = drange(
-                ((cjfee_highx - cjfee_lowx) / num_offers), cjfee_highx,
-                (cjfee_highx - cjfee_lowx) / (num_offers - 1))  # evenly spaced
-            cjfee_levels = ["%0.7f" % x for x in cjfee_levels] + [cjfee_highx]
+            cjfee_levels = drange(cjfee_lowx, cjfee_highx,
+                                  (cjfee_highx - cjfee_lowx) /
+                                  (num_offers - 1))  # evenly spaced
+            cjfee_levels = ["%0.7f" % x for x in cjfee_levels]
         elif cjfee_spread == 'random':
             cjfee_levels = sorted(
-                ["%0.7f" % random.uniform(cjfee_lowx, cjfee_highx)
+                ["%0.7f" % random.uniform(
+                    float(cjfee_lowx), float(cjfee_highx))
                  for n in range(num_offers)])  # randomly spaced
         elif cjfee_spread == 'custom':
             cjfee_levels = [str(decimal.Decimal(str(x)) / 100)
@@ -247,34 +283,59 @@ class YieldGenerator(Maker):
         # TXFees
         if txfee_spread == 'fibonacci':
             txfee_levels = fib_seq(txfee_low, txfee_high, num_offers)
+            txfee_levels = [int(round(x)) for x in txfee_levels]
         elif txfee_spread == 'evenly':
-            txfee_levels = list(range(
-                ((txfee_high - txfee_low) / num_offers), txfee_high, (
-                    txfee_high - txfee_low) / (num_offers - 1))) + [txfee_high]
+            txfee_levels = list(range(txfee_low, txfee_high, (
+                txfee_high - txfee_low) / (num_offers - 1)))
+            txfee_levels = txfee_levels[0:(num_offers - 1)] + [txfee_high]
         elif txfee_spread == 'random':
             txfee_levels = sorted([random.randrange(txfee_low, txfee_high)
                                    for n in range(num_offers - 1)] +
                                   [random.randrange(txfee_high - (
                                       txfee_high / num_offers), txfee_high)])
         elif txfee_spread == 'custom':
-            txfee_levels = [x for x in sorted(custom_txfees)]
+            txfee_levels = [x for x in custom_txfees]
+        else:
+            log.debug('invalid txfee_spread = ' + str(txfee_spread))
+            sys.exit(0)
 
         log.debug('offer_levels = ' + str(offer_levels))
         lower_bound_balances = [offer_lowx] + [x for x in offer_levels[:-1]]
+        if offer_spread == 'bymixdepth':
+            cjfee_levels = cjfee_levels[-len(offer_levels):]
+            txfee_levels = txfee_levels[-len(offer_levels):]
         offer_ranges = zip(offer_levels, lower_bound_balances, cjfee_levels,
                            txfee_levels)
         log.debug('offer_ranges = ' + str(offer_ranges))
         offers = []
         oid = 0
+
+        # create absorders for mixdepth dust
+        offer_levels = []
+        for m in sorted_mix_balance:
+            if m[1] == 0:
+                continue
+            #elif False: # disabled
+            #elif m[1] <= 2e8:  # absorder all mixdepths less then
+            elif m[1] <= offer_lowx:
+                offer = {'oid': oid,
+                         'ordertype': 'absorder',
+                         'minsize': m[1],
+                         'maxsize': m[1],
+                         'txfee': 0,
+                         'cjfee': 0}
+                #'txfee': txfee_low,
+                #'cjfee': min_revenue}
+                oid += 1
+                offers.append(offer)
+            elif m[1] > offer_lowx:
+                break
+
         for upper, lower, cjfee, txfee in offer_ranges:
-            # minimum cjfee you require for your offers
-            #min_cjfee = random.randrange(txfee, txfee * 5)  # random
-            #min_cjfee = int(1.5 * txfee) # 50% net revenue
-            min_cjfee = 0  # no profit required
             if float(cjfee) > 0:
-                min_needed = int(min_cjfee / float(cjfee))
+                min_needed = int(min_revenue / float(cjfee))
             else:
-                min_needed = min_cjfee
+                min_needed = min_revenue
             if min_needed <= lower:
                 # create a regular relorder
                 offer = {'oid': oid,
@@ -290,7 +351,7 @@ class YieldGenerator(Maker):
                          'minsize': lower,
                          'maxsize': min_needed - 1,
                          'txfee': txfee,
-                         'cjfee': min_cjfee}
+                         'cjfee': min_revenue}
                 oid += 1
                 offers.append(offer)
                 offer = {'oid': oid,
@@ -306,53 +367,111 @@ class YieldGenerator(Maker):
                          'minsize': lower,
                          'maxsize': upper,
                          'txfee': txfee,
-                         'cjfee': min_cjfee}
+                         'cjfee': min_revenue}
                 # todo: combine neighboring absorders into a single one
             oid += 1
             offers.append(offer)
 
+        deluxe_offer_display = []
+        header = 'oid'.rjust(5)
+        header += 'type'.rjust(7)
+        header += 'minsize btc'.rjust(15)
+        header += 'maxsize btc'.rjust(15)
+        header += 'min revenue satosh'.rjust(22)
+        header += 'max revenue satosh'.rjust(22)
+        deluxe_offer_display.append(header)
+        for o in offers:
+            line = str(o['oid']).rjust(5)
+            if o['ordertype'] == 'absorder':
+                line += 'abs'.rjust(7)
+            elif o['ordertype'] == 'relorder':
+                line += 'rel'.rjust(7)
+            line += str(o['minsize'] / 1e8).rjust(15)
+            line += str(o['maxsize'] / 1e8).rjust(15)
+            if o['ordertype'] == 'absorder':
+                line += str(o['cjfee']).rjust(22)
+            elif o['ordertype'] == 'relorder':
+                line += str(int(float(o['cjfee']) * int(o['minsize']))).rjust(
+                    22)
+                line += str(int(float(o['cjfee']) * int(o['maxsize']))).rjust(
+                    22)
+            deluxe_offer_display.append(line)
+
+        log.debug('deluxe offer display = \n' + '\n'.join([str(
+            x) for x in deluxe_offer_display]))
+
         log.debug('generated offers = \n' + '\n'.join([str(o) for o in offers]))
+
+        # sanity check
+        for offer in offers:
+            assert offer['minsize'] >= 0
+            assert offer['maxsize'] > 0
+            assert offer['minsize'] <= offer['maxsize']
+
         return offers
 
     def oid_to_order(self, cjorder, oid, amount):
         '''Coins rotate circularly from max mixdepth back to mixdepth 0'''
         mix_balance = self.wallet.get_balance_by_mixdepth()
+        total_amount = amount + cjorder.txfee
+        log.debug('amount, txfee, total_amount = ' + str(amount) + str(
+            cjorder.txfee) + str(total_amount))
+
+        # look for exact amount available with no change
         filtered_mix_balance = [m
                                 for m in mix_balance.iteritems()
-                                if m[1] >= amount]
-        log.debug('mix depths that have enough, filtered_mix_balance = ' + str(
-            filtered_mix_balance))
+                                if m[1] == total_amount]
+        if filtered_mix_balance:
+            log.debug('mix depths that have the exact amount needed = ' + str(
+                filtered_mix_balance))
+        else:
+            log.debug('no mix depths contain the exact amount needed.')
+            filtered_mix_balance = [m
+                                    for m in mix_balance.iteritems()
+                                    if m[1] >= total_amount]
+            log.debug('mix depths that have enough = ' + str(
+                filtered_mix_balance))
+            filtered_mix_balance = [m
+                                    for m in mix_balance.iteritems()
+                                    if m[1] >= total_amount + min_output_size]
+            log.debug('mix depths that have enough with min_output_size, ' +
+                      str(filtered_mix_balance))
+            try:
+                len(filtered_mix_balance) > 0
+            except Exception:
+                log.debug('No mix depths have enough funds to cover the ' +
+                          'amount, cjfee, and min_output_size.')
+                return None, None, None
 
         # clumping. push all coins towards the largest mixdepth
         # the largest amount of coins are available to join with (since joins always come from a single depth)
         # the maker commands a higher fee for the larger amounts 
+        # order ascending but circularly with largest last
         # note, no need to consider max_offer_size here
-        largest_mixdepth = sorted(filtered_mix_balance,
-                                  key=lambda x: x[1],
-                                  reverse=True)[0]  # find largest amount
-        filtered_mix_balance = sorted(
+        largest_mixdepth = sorted(
             filtered_mix_balance,
-            key=lambda x: x[0])  # make sure we are in seq of mixdepth num
-
-        filtered_mix_balance[
-            (filtered_mix_balance.index(largest_mixdepth) + 1
-            ) % self.wallet.max_mix_depth:] + filtered_mix_balance[:(
-                filtered_mix_balance.index(largest_mixdepth) + 1
-            ) % self.wallet.max_mix_depth]  # order ascending but circularly with largest last
-
-        # use mix depth with the most coins, 
-        # creates a more even distribution across mix depths
-        # and a more diverse txo selection in each depth
-        # filtered_mix_balance = sorted(filtered_mix_balance, key=lambda x: x[1], reverse=True)  #sort largest to smallest amount
+            key=lambda x: x[1],)[-1]  # find largest amount
+        smb = sorted(filtered_mix_balance,
+                     key=lambda x: x[0])  # seq of mixdepth num
+        next_index = smb.index(largest_mixdepth) + 1
+        mmd = self.wallet.max_mix_depth
+        filtered_mix_balance = smb[next_index % mmd:] + smb[:next_index % mmd]
 
         # use mix depth that has the closest amount of coins to what this transaction needs
         # keeps coins moving through mix depths more quickly
         # and its more likely to use txos of a similiar size to this transaction
-        # filtered_mix_balance = sorted(filtered_mix_balance, key=lambda x: x[1])  #sort smallest to largest usable amount
+        # sort smallest to largest usable amount
+        #filtered_mix_balance = sorted(filtered_mix_balance, key=lambda x: x[1])
+
+        # use mix depth with the most coins, 
+        # creates a more even distribution across mix depths
+        # and a more diverse txo selection in each depth
+        # sort largest to smallest amount
+        #filtered_mix_balance = sorted(filtered_mix_balance, key=lambda x: x[1], reverse=True)
 
         # use a random usable mixdepth. 
         # warning, could expose more txos to malicous taker requests
-        # filtered_mix_balance = random.choice(filtered_mix_balance)
+        #filtered_mix_balance = random.choice(filtered_mix_balance)
 
         log.debug('sorted order of filtered_mix_balance = ' + str(
             filtered_mix_balance))
@@ -366,7 +485,7 @@ class YieldGenerator(Maker):
                                                self.wallet.max_mix_depth)
         change_addr = self.wallet.get_change_addr(mixdepth)
 
-        utxos = self.wallet.select_utxos(mixdepth, amount)
+        utxos = self.wallet.select_utxos(mixdepth, total_amount)
         my_total_in = sum([va['value'] for va in utxos.values()])
         real_cjfee = calc_cj_fee(cjorder.ordertype, cjorder.cjfee, amount)
         change_value = my_total_in - amount - cjorder.txfee + real_cjfee
@@ -375,7 +494,7 @@ class YieldGenerator(Maker):
                       % (change_value))
             try:
                 utxos = self.wallet.select_utxos(mixdepth,
-                                                 amount + min_output_size)
+                                                 total_amount + min_output_size)
             except Exception:
                 log.debug(
                     'dont have the required UTXOs to make a output above the dust threshold, quitting')

--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -89,7 +89,7 @@ class YieldGenerator(Maker):
                                     if b > jm_single().DUST_THRESHOLD])
         if len(nondust_mix_balance) == 0:
             log.debug('do not have any coins left')
-            sys.exit(0)
+            return []
         #sorts the mixdepth_balance map by balance size
         sorted_mix_balance = sorted(
             list(mix_balance.iteritems()),
@@ -99,6 +99,7 @@ class YieldGenerator(Maker):
             1.5 * txfee / float(min(cjfee))
         )  #minimum size is such that you always net profit at least 50% of the miner fee
         filtered_mix_balance = [f for f in sorted_mix_balance if f[1] > minsize]
+        delta = mix_levels - len(filtered_mix_balance)
         log.debug('minsize=' + str(minsize) + ' calc\'d with cjfee=' + str(min(
             cjfee)))
         lower_bound_balances = filtered_mix_balance[1:] + [(-1, minsize)]
@@ -123,7 +124,7 @@ class YieldGenerator(Maker):
                      'maxsize': max(balance - jm_single().DUST_THRESHOLD,
                                     jm_single().DUST_THRESHOLD),
                      'txfee': txfee,
-                     'cjfee': thecjfee[oid],
+                     'cjfee': thecjfee[oid + delta],
                      'mixdepth': mixdepth}
             oid += 1
             orders.append(order)
@@ -143,13 +144,21 @@ class YieldGenerator(Maker):
                      'cjfee': absorder_fee}
             orders = [order] + orders
         log.debug('generated orders = \n' + '\n'.join([str(o) for o in orders]))
+
+        # sanity check
+        for order in orders:
+            assert order['minsize'] >= 0
+            assert order['maxsize'] > 0
+            assert order['minsize'] <= order['maxsize']
+
         return orders
 
     def oid_to_order(self, cjorder, oid, amount):
+        total_amount = amount + cjorder.txfee
         mix_balance = self.wallet.get_balance_by_mixdepth()
         filtered_mix_balance = [m
                                 for m in mix_balance.iteritems()
-                                if m[1] >= amount]
+                                if m[1] >= total_amount]
         log.debug('mix depths that have enough, filtered_mix_balance = ' + str(
             filtered_mix_balance))
 
@@ -172,7 +181,7 @@ class YieldGenerator(Maker):
                                                self.wallet.max_mix_depth)
         change_addr = self.wallet.get_change_addr(mixdepth)
 
-        utxos = self.wallet.select_utxos(mixdepth, amount)
+        utxos = self.wallet.select_utxos(mixdepth, total_amount)
         my_total_in = sum([va['value'] for va in utxos.values()])
         real_cjfee = calc_cj_fee(cjorder.ordertype, cjorder.cjfee, amount)
         change_value = my_total_in - amount - cjorder.txfee + real_cjfee
@@ -181,7 +190,7 @@ class YieldGenerator(Maker):
                       % (change_value))
             try:
                 utxos = self.wallet.select_utxos(
-                    mixdepth, amount + jm_single().DUST_THRESHOLD)
+                    mixdepth, total_amount + jm_single().DUST_THRESHOLD)
             except Exception:
                 log.debug(
                     'dont have the required UTXOs to make a output above the dust threshold, quitting')


### PR DESCRIPTION
This resolves issues #106 and #358.

Also fixed an issue where the txfee contribution was not being taken account of when filling orders, which could have rarely been causing crashes if the total amount surpassed the utxo selection.

Added dust exact sized absolute offers. 

ygbasic and ygmixdepth both pass regtest
ygdeluxe only passes when its configuration options are greatly simplified so that it only creates a single order. I guess an issue with how the test selects orders. The error being thrown is  https://bpaste.net/show/e82a247f1608