### PR TITLE
Adding helpful message when an unhandled path is sent to the http notify request

### DIFF
--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -440,6 +440,9 @@ class NotifyRequestHeader(BaseHTTPServer.BaseHTTPRequestHandler):
             jm_single().core_alert = urllib.unquote(self.path[len(pages[1]):])
             log.debug('Got an alert!\nMessage=' + jm_single().core_alert)
 
+        else:
+            log.debug('ERROR: This is not a handled URL path.  You may want to check your notify URL for typos.')
+
         os.system('curl -sI --connect-timeout 1 http://localhost:' + str(
                 self.base_server.server_address[1] + 1) + self.path)
         self.send_response(200)


### PR DESCRIPTION
I was stuck for a time with a typo in my notify request that I set up in bitcoin.conf.  This message would have been really helpful to let me know what I should check for when running the project to get past my issue.