### PR TITLE
clump coins to max mixdepth, dev

### DIFF
--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -96,17 +96,17 @@ class YieldGenerator(Maker):
         mix_balance = self.wallet.get_balance_by_mixdepth()
         max_mix = max(mix_balance, key=mix_balance.get)
 
-        # algo attempts to make the largest-balance mixing depth get an even
-        # larger balance
-        log.debug('finding suitable mixdepth')
-        mixdepth = (max_mix - 1) % self.wallet.max_mix_depth
-        while True:
-            if mixdepth in mix_balance and mix_balance[mixdepth] >= total_amount:
-                break
-            mixdepth = (mixdepth - 1) % self.wallet.max_mix_depth
+        filtered_mix_balance = [m
+                                for m in mix_balance.iteritems()
+                                if m[1] >= total_amount]
+        log.debug('mix depths that have enough = ' + str(filtered_mix_balance))
+        filtered_mix_balance = sorted(filtered_mix_balance, key=lambda x: x[0])
+        mixdepth = filtered_mix_balance[0][0]
+        log.debug('filling offer, mixdepth=' + str(mixdepth))
+
         # mixdepth is the chosen depth we'll be spending from
-        cj_addr = self.wallet.get_internal_addr(
-            (mixdepth + 1) % self.wallet.max_mix_depth)
+        cj_addr = self.wallet.get_internal_addr((mixdepth + 1) %
+                                                self.wallet.max_mix_depth)
         change_addr = self.wallet.get_internal_addr(mixdepth)
 
         utxos = self.wallet.select_utxos(mixdepth, total_amount)

--- a/yield-generator-deluxe.py
+++ b/yield-generator-deluxe.py
@@ -443,19 +443,24 @@ class YieldGenerator(Maker):
                           'amount, cjfee, and min_output_size.')
                 return None, None, None
 
+        # prioritize by mixdepths sequencially
+        # keep coins moving towards last mixdepth, clumps once they get there
+        # makes sure coins sent to mixdepth 0 will get mixed to max mixdepth
+        filtered_mix_balance = sorted(filtered_mix_balance, key=lambda x: x[0])
+
         # clumping. push all coins towards the largest mixdepth
         # the largest amount of coins are available to join with (since joins always come from a single depth)
         # the maker commands a higher fee for the larger amounts 
         # order ascending but circularly with largest last
         # note, no need to consider max_offer_size here
-        largest_mixdepth = sorted(
-            filtered_mix_balance,
-            key=lambda x: x[1],)[-1]  # find largest amount
-        smb = sorted(filtered_mix_balance,
-                     key=lambda x: x[0])  # seq of mixdepth num
-        next_index = smb.index(largest_mixdepth) + 1
-        mmd = self.wallet.max_mix_depth
-        filtered_mix_balance = smb[next_index % mmd:] + smb[:next_index % mmd]
+        #largest_mixdepth = sorted(
+        #    filtered_mix_balance,
+        #    key=lambda x: x[1],)[-1]  # find largest amount
+        #smb = sorted(filtered_mix_balance,
+        #             key=lambda x: x[0])  # seq of mixdepth num
+        #next_index = smb.index(largest_mixdepth) + 1
+        #mmd = self.wallet.max_mix_depth
+        #filtered_mix_balance = smb[next_index % mmd:] + smb[:next_index % mmd]
 
         # use mix depth that has the closest amount of coins to what this transaction needs
         # keeps coins moving through mix depths more quickly
@@ -481,8 +486,8 @@ class YieldGenerator(Maker):
         log.debug('filling offer, mixdepth=' + str(mixdepth))
 
         # mixdepth is the chosen depth we'll be spending from
-        cj_addr = self.wallet.get_internal_addr(
-            (mixdepth + 1) % self.wallet.max_mix_depth)
+        cj_addr = self.wallet.get_internal_addr((mixdepth + 1) %
+                                                self.wallet.max_mix_depth)
         change_addr = self.wallet.get_internal_addr(mixdepth)
 
         utxos = self.wallet.select_utxos(mixdepth, total_amount)

--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -177,8 +177,8 @@ class YieldGenerator(Maker):
         log.debug('filling offer, mixdepth=' + str(mixdepth))
 
         # mixdepth is the chosen depth we'll be spending from
-        cj_addr = self.wallet.get_internal_addr(
-            (mixdepth + 1) % self.wallet.max_mix_depth)
+        cj_addr = self.wallet.get_internal_addr((mixdepth + 1) %
+                                                self.wallet.max_mix_depth)
         change_addr = self.wallet.get_internal_addr(mixdepth)
 
         utxos = self.wallet.select_utxos(mixdepth, total_amount)


### PR DESCRIPTION
With the current 'clumping' oid_to_order code, since it tries to clump into what is already the largest pile, coins wont move through the mixdepths if no large orders come in. Once a small amount of coins leave the largest pile, they will circulate all the way around and end up in the big pile again. I propose the way this should be dealt with is to prioritize by mixdepth number. So that coins in mixdepth0 are spent first, then mixdepth1, and lastly max_mix_depth. This will still tend towards clumping, but always at the last 
mixdepth, causing coins to move through to the max depth when deposited in mixdepth 0. 
