### PR TITLE
disallow non-integer absorders in on_order_seen

### DIFF
--- a/joinmarket/taker.py
+++ b/joinmarket/taker.py
@@ -456,6 +456,13 @@ class OrderbookWatch(CoinJoinerPeer):
                        "from {}").format
                 log.debug(fmt(minsize, maxsize, counterparty))
                 return
+            if ordertype == 'absorder' and not isinstance(cjfee, int):
+                try:
+                    cjfee = int(cjfee)
+                except ValueError:
+                    log.debug("Got non integer coinjoin fee: " + str(cjfee) +
+                            " for an absorder from " + counterparty)
+                    return
             self.db.execute(
                     'INSERT INTO orderbook VALUES(?, ?, ?, ?, ?, ?, ?);',
                     (counterparty, oid, ordertype, minsize, maxsize, txfee,


### PR DESCRIPTION
See #390 .

It makes me realise that any protocol 'expansions' have to pay particular attention to on_order_seen.

This is basically assuming that we don't need to catch a valueerror anywhere else based on the value of 'cjfee', as long as we don't let anything invalid come in in the first place.

Minimal testing done, but it seems uncontroversial. ACKs or NACKs appreciated.