### PR TITLE
put back joinmarket alerts and core alerts

### DIFF
--- a/joinmarket/__init__.py
+++ b/joinmarket/__init__.py
@@ -5,7 +5,7 @@ import logging
 from .support import get_log, calc_cj_fee, debug_dump_object, \
     choose_sweep_orders, choose_orders, \
     pick_order, cheapest_order_choose, weighted_order_choose, \
-    rand_norm_array, rand_pow_array, rand_exp_array
+    rand_norm_array, rand_pow_array, rand_exp_array, joinmarket_alert, core_alert
 from .enc_wrapper import decode_decrypt, encrypt_encode, get_pubkey
 from .irc import IRCMessageChannel, random_nick
 from .jsonrpc import JsonRpcError, JsonRpcConnectionError, JsonRpc

--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -437,8 +437,8 @@ class NotifyRequestHeader(BaseHTTPServer.BaseHTTPRequestHandler):
                     log.debug('ran confirmfun')
 
         elif self.path.startswith('/alertnotify?'):
-            jm_single().core_alert = urllib.unquote(self.path[len(pages[1]):])
-            log.debug('Got an alert!\nMessage=' + jm_single().core_alert)
+            jm_single().core_alert[0] = urllib.unquote(self.path[len(pages[1]):])
+            log.debug('Got an alert!\nMessage=' + jm_single().core_alert[0])
 
         else:
             log.debug('ERROR: This is not a handled URL path.  You may want to check your notify URL for typos.')

--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -8,7 +8,7 @@ from ConfigParser import SafeConfigParser, NoOptionError
 
 import bitcoin as btc
 from joinmarket.jsonrpc import JsonRpc
-from joinmarket.support import get_log
+from joinmarket.support import get_log, joinmarket_alert, core_alert
 
 # config = SafeConfigParser()
 # config_location = 'joinmarket.cfg'
@@ -80,8 +80,8 @@ global_singleton.ordername_list = ['absorder', 'relorder']
 global_singleton.maker_timeout_sec = 60
 global_singleton.debug_file_lock = threading.Lock()
 global_singleton.debug_file_handle = None
-global_singleton.core_alert = None
-global_singleton.joinmarket_alert = None
+global_singleton.core_alert = core_alert
+global_singleton.joinmarket_alert = joinmarket_alert
 global_singleton.debug_silence = False
 global_singleton.config = SafeConfigParser()
 global_singleton.config_location = 'joinmarket.cfg'

--- a/joinmarket/support.py
+++ b/joinmarket/support.py
@@ -29,7 +29,22 @@ logFormatter = logging.Formatter(
 log = logging.getLogger('joinmarket')
 log.setLevel(logging.DEBUG)
 
-consoleHandler = logging.StreamHandler(stream=sys.stdout)
+joinmarket_alert = ['']
+core_alert = ['']
+
+#consoleHandler = logging.StreamHandler(stream=sys.stdout)
+class JoinMarketStreamHandler(logging.StreamHandler):
+    def __init__(self, stream):
+        super(JoinMarketStreamHandler, self).__init__(stream)
+
+    def emit(self, record):
+        if joinmarket_alert[0]:
+            print('JoinMarket Alert Message: ' + joinmarket_alert[0])
+        if core_alert[0]:
+            print('Core Alert Message: ' + core_alert[0])
+        super(JoinMarketStreamHandler, self).emit(record)
+
+consoleHandler = JoinMarketStreamHandler(stream=sys.stdout)
 consoleHandler.setFormatter(logFormatter)
 log.addHandler(consoleHandler)
 

--- a/joinmarket/taker.py
+++ b/joinmarket/taker.py
@@ -405,8 +405,7 @@ class CoinJoinerPeer(object):
                 print('JOINMARKET ALERT')
                 print(alert)
                 print('=' * 60)
-                # todo: is this right?
-                jm_single().joinmarket_alert = alert
+                jm_single().joinmarket_alert[0] = alert
 
 
 class OrderbookWatch(CoinJoinerPeer):

--- a/ob-watcher.py
+++ b/ob-watcher.py
@@ -234,9 +234,9 @@ class OrderbookPageRequestHeader(SimpleHTTPServer.SimpleHTTPRequestHandler):
         orderbook_fmt = fd.read()
         fd.close()
         alert_msg = ''
-        if jm_single().joinmarket_alert:
+        if jm_single().joinmarket_alert[0]:
             alert_msg = '<br />JoinMarket Alert Message:<br />' + \
-                        jm_single().joinmarket_alert
+                        jm_single().joinmarket_alert[0]
         if self.path == '/':
             btc_unit = args['btcunit'][
                 0] if 'btcunit' in args else sorted_units[0]


### PR DESCRIPTION
adds two global (module) vars in support.py which are referenced in global_singleton in common.py (done this way due to circular references if trying to refer to jm_single from support.py). JoinmarketStreamHandler provided by @chris-belcher 