### PR TITLE
Always load default config with initial values first, then load poten…

### DIFF
--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -188,11 +188,11 @@ def validate_address(addr):
 
 
 def load_program_config():
+    global_singleton.config.readfp(io.BytesIO(defaultconfig))
     loadedFiles = global_singleton.config.read(
             [global_singleton.config_location])
     # Create default config file if not found
     if len(loadedFiles) != 1:
-        global_singleton.config.readfp(io.BytesIO(defaultconfig))
         with open(global_singleton.config_location, "w") as configfile:
             configfile.write(defaultconfig)
 


### PR DESCRIPTION
…tial config file afterwards

This is almost the exact literal example use case of the ConfigParser docu[1].


1 - https://docs.python.org/2/library/configparser.html#ConfigParser.RawConfigParser.read