### PR TITLE
Loop on irc.connect() in order to survive to connection errors

### DIFF
--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -185,17 +185,18 @@ def main():
                                 "BLOCKCHAIN", "blockchain_source"),
                             password=nickserv_password)
     maker = YieldGenerator(irc, wallet)
-    try:
-        log.debug('connecting to irc')
-        irc.run()
-    except:
-        log.debug('CRASHING, DUMPING EVERYTHING')
-        debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
-        debug_dump_object(maker)
-        debug_dump_object(irc)
-        import traceback
-        log.debug(traceback.format_exc())
-
+    while True:
+        try:
+            log.debug('connecting to irc')
+            irc.run()
+        except:
+            log.debug('CRASHING, DUMPING EVERYTHING')
+            debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
+            debug_dump_object(maker)
+            debug_dump_object(irc)
+            import traceback
+            log.debug(traceback.format_exc())
+        time.sleep(60)
 
 if __name__ == "__main__":
     main()

--- a/yield-generator-deluxe.py
+++ b/yield-generator-deluxe.py
@@ -581,17 +581,18 @@ def main():
                                 "BLOCKCHAIN", "blockchain_source"),
                             password=nickserv_password)
     maker = YieldGenerator(irc, wallet)
-    try:
-        log.debug('connecting to irc')
-        irc.run()
-    except:
-        log.debug('CRASHING, DUMPING EVERYTHING')
-        debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
-        debug_dump_object(maker)
-        debug_dump_object(irc)
-        import traceback
-        log.debug(traceback.format_exc())
-
+    while True:
+        try:
+            log.debug('connecting to irc')
+            irc.run()
+        except:
+            log.debug('CRASHING, DUMPING EVERYTHING')
+            debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
+            debug_dump_object(maker)
+            debug_dump_object(irc)
+            import traceback
+            log.debug(traceback.format_exc())
+        time.sleep(60)
 
 if __name__ == "__main__":
     main()

--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -309,17 +309,18 @@ def main():
                                 "BLOCKCHAIN", "blockchain_source"),
                             password=nickserv_password)
     maker = YieldGenerator(irc, wallet)
-    try:
-        log.debug('connecting to irc')
-        irc.run()
-    except:
-        log.debug('CRASHING, DUMPING EVERYTHING')
-        debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
-        debug_dump_object(maker)
-        debug_dump_object(irc)
-        import traceback
-        log.debug(traceback.format_exc())
-
+    while True:
+        try:
+            log.debug('connecting to irc')
+            irc.run()
+        except:
+            log.debug('CRASHING, DUMPING EVERYTHING')
+            debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
+            debug_dump_object(maker)
+            debug_dump_object(irc)
+            import traceback
+            log.debug(traceback.format_exc())
+        time.sleep(60)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
My yield-generator dies on connection errors. I solved the problem in this way

> 2016-01-29 01:55:26,584 [MainThread  ] [DEBUG]  None
2016-01-29 01:55:26,584 [MainThread  ] [DEBUG]  Traceback (most recent call last):
  File "./yield-generator-mixdepth.py", line 315, in main
    irc.run()
  File "/home/joinmarket/multijm/2/joinmarket/irc.py", line 617, in run
    self.sock.connect(self.serverport)
  File "/home/joinmarket/multijm/2/joinmarket/socks.py", line 391, in connect
    self.__negotiatesocks5(destpair[0], destpair[1])
  File "/home/joinmarket/multijm/2/joinmarket/socks.py", line 255, in __negotiatesocks5
    raise Socks5Error(_socks5errors[min(9, ord(resp[1]))])
Socks5Error: 'TTL expired'