### PR TITLE
stop yield-generator-mixdepth announcing absorders if they havent bee…

### DIFF
--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -218,15 +218,15 @@ class YieldGenerator(Maker):
 		'''
 
         myorders = self.create_my_orders()
-        oldorders = self.orderlist
+        oldorderlist = self.orderlist
         if len(myorders) == 0:
-            return ([o['oid'] for o in oldorders], [])
+            return ([o['oid'] for o in oldorderlist], [])
 
         cancel_orders = []
         ann_orders = []
 
         neworders = [o for o in myorders if o['ordertype'] == 'relorder']
-        oldorders = [o for o in oldorders if o['ordertype'] == 'relorder']
+        oldorders = [o for o in oldorderlist if o['ordertype'] == 'relorder']
         #new_setdiff_old = The relative complement of `new` in `old` = members in `new` which are not in `old`
         new_setdiff_old = [o for o in neworders if o not in oldorders]
         old_setdiff_new = [o for o in oldorders if o not in neworders]
@@ -250,7 +250,7 @@ class YieldGenerator(Maker):
 
         #check if the absorder has changed, or if it needs to be newly announced
         new_abs = [o for o in myorders if o['ordertype'] == 'absorder']
-        old_abs = [o for o in oldorders if o['ordertype'] == 'absorder']
+        old_abs = [o for o in oldorderlist if o['ordertype'] == 'absorder']
         if len(new_abs) > len(old_abs):
             #announce an absorder where there wasnt one before
             ann_orders = [new_abs[0]] + ann_orders


### PR DESCRIPTION
…n modified

To stop stuff like this where the same absorder is announced again and again

	<Wipiziyik> !absorder 0 2731 68179088 5000 8182 ~
	<Lebiyikon> !absorder 0 2731 68179088 5000 8864 ~
	<Wipiziyik> !absorder 0 2731 68179088 5000 8182 ~
	<Lebiyikon> !absorder 0 2731 68179088 5000 8864 ~
	<Wipiziyik> !absorder 0 2731 68179088 5000 8182 ~
	<Povovepix> !cancel 2
	<Wipiziyik> !cancel 1
	<Povovepix> !absorder 0 2731 68179088 5000 8182!relorder 1 68179089 897087792 5000 0.00015 ~
	<Wipiziyik> !absorder 0 2731 31090346 5000 7500 ~
	<Wipiziyik> !absorder 0 2731 68179088 5000 8182!relorder 1 68179089 802405132 5000 0.00015 ~
	<Povovepix> !absorder 0 2731 68179088 5000 8182 ~
	<Povovepix> !absorder 0 2731 68179088 5000 8182 ~
	<Wipiziyik> !absorder 0 2731 68179088 5000 8182 ~
	<Wipiziyik> !absorder 0 2731 68179088 5000 8182 ~
	<Povovepix> !absorder 0 2731 68179088 5000 8182 ~

The cause of the bug is this

     oldorders = [o for o in oldorders if o['ordertype'] == 'relorder']

which means `oldorders` contains only relorders, but later this line will be called

    old_abs = [o for o in oldorders if o['ordertype'] == 'absorder']

since oldorders only contains relorders, `old_abs` will always be empty