### PR TITLE
Obfuscate maker bot identities

### DIFF
--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -116,11 +116,16 @@ socks5 = false
 socks5_host = localhost
 socks5_port = 9050
 #for tor
-#host = 6dvj6v5imhny3anf.onion
+#newnym = true
+#newnym_delay = 60
+#tor_host = localhost
+#tor_port = 9051
+#tor_pass =
 #port = 6697
 #usessl = true
 #socks5 = true
 maker_timeout_sec = 30
+reconnect_delay = 30
 
 [POLICY]
 # for dust sweeping, try merge_algorithm = gradual

--- a/joinmarket/irc.py
+++ b/joinmarket/irc.py
@@ -8,6 +8,7 @@ import threading
 import time
 import Queue
 
+from ConfigParser import NoOptionError
 from joinmarket.configure import jm_single, get_config_irc_channel
 from joinmarket.message_channel import MessageChannel, CJPeerError
 from joinmarket.enc_wrapper import encrypt_encode, decode_decrypt
@@ -497,8 +498,9 @@ class IRCMessageChannel(MessageChannel):
                 if self.on_nick_leave:
                     self.on_nick_leave(nick)
         elif _chunks[1] == '433':  # nick in use
-            # self.nick = random_nick()
             self.nick += '_'  # helps keep identity constant if just _ added
+            if self.newnyms:
+                self.nick = random_nick()
             self.send_raw('NICK ' + self.nick)
         if self.password:
             if _chunks[1] == 'CAP':
@@ -583,12 +585,38 @@ class IRCMessageChannel(MessageChannel):
         self.socks5_port = int(config.get("MESSAGING", "socks5_port"))
         self.channel = get_config_irc_channel()
         self.userrealname = (username, realname)
+        self.reconnect_delay = 30
+        self.newnyms = False
+        try:
+            self.reconnect_delaty = int(config.get("MESSAGING", "reconnect_delay"))
+            self.newnyms = (config.get("MESSAGING", "newnym").lower() == 'true')
+            self.tor_host = config.get("MESSAGING", "tor_host")
+            self.tor_port = int(config.get("MESSAGING", "tor_port"))
+            self.tor_pass = config.get("MESSAGING", "tor_pass")
+            self.newnym_delay = int(config.get("MESSAGING", "newnym_delay"))
+        except NoOptionError as ex:
+            log.debug('The following newnym option is missing:')
+            log.debug(ex)
+            log.debug('.. disabling the feature.')
+            self.newnyms = False
         if password and len(password) == 0:
             password = None
         self.given_password = password
         self.pingQ = Queue.Queue()
         self.throttleQ = Queue.Queue()
         self.obQ = Queue.Queue()
+
+    def newnym(self):
+        ctrl = socket.create_connection((self.tor_host, self.tor_port))
+        ctrl.send('AUTHENTICATE "%s"\r\n'%self.tor_pass)
+        resp = ctrl.recv(1024)
+        if resp.startswith('250'):
+            ctrl.send("signal NEWNYM\r\n")
+            if resp.startswith('250'):
+                ctrl.close()
+                return
+        ctrl.close()
+        raise IOError("newnym failed "+resp)
 
     def run(self):
         self.waiting = {}
@@ -604,6 +632,10 @@ class IRCMessageChannel(MessageChannel):
             try:
                 config = jm_single().config
                 log.debug('connecting')
+                if self.newnyms:
+                    log.debug("Grabbing new Tor identity")
+                    self.newnym()
+                    self.nick = random_nick()
                 if config.get("MESSAGING", "socks5").lower() == 'true':
                     log.debug("Using socks5 proxy %s:%d" %
                               (self.socks5_host, self.socks5_port))
@@ -649,6 +681,8 @@ class IRCMessageChannel(MessageChannel):
                 self.on_disconnect()
             log.debug('disconnected irc')
             if not self.give_up:
-                time.sleep(30)
+                time.sleep(self.reconnect_delay)
+                if self.newnyms:
+                    time.sleep(random.randint(0,self.newnym_delay))
         log.debug('ending irc')
         self.give_up = True

--- a/joinmarket/maker.py
+++ b/joinmarket/maker.py
@@ -213,7 +213,8 @@ class Maker(CoinJoinerPeer):
         self.active_orders = {}
         self.wallet = wallet
         self.nextoid = -1
-        self.orderlist = self.create_my_orders()
+        if not self.msgchan.newnyms:
+            self.orderlist = self.create_my_orders()
         self.wallet_unspent_lock = threading.Lock()
 
     def get_crypto_box_from_nick(self, nick):
@@ -265,6 +266,8 @@ class Maker(CoinJoinerPeer):
             self.msgchan.send_error(nick, 'Unable to push tx')
 
     def on_welcome(self):
+        if self.msgchan.newnyms:
+            self.orderlist = self.create_my_orders()
         self.msgchan.announce_orders(self.orderlist)
         self.active_orders = {}
 

--- a/joinmarket/message_channel.py
+++ b/joinmarket/message_channel.py
@@ -29,6 +29,8 @@ class MessageChannel(object):
         self.on_seen_auth = None
         self.on_seen_tx = None
         self.on_push_tx = None
+        # chan-specific attributes
+        self.newnyms = False
 
     def run(self):
         pass


### PR DESCRIPTION
Currently the codebase makes weak attempts to disclose the long term identity of a  maker, which somewhat irks me.

These patches make the bot assume a new identity on every IRC reconnect. While it can still be somewhat tracked via its published summary amounts it makes it at least somewhat non-trivial.

Future improvements: To make the identity obfuscation more robust, we'd need a split personality - basically small number of sybils, but in a good way.

The feature is optional and disabled by default.

I am aware this is a possible tool of sybil attackers. That would happen one way or another, massive sybils must be prevented through effective means - market forces, coin age and privately, F2F established identities - not nicknames / u@h.