### PR TITLE
Fix crash in yield generator mixdepth when no unconfirm notify arrives

### DIFF
--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -268,9 +268,9 @@ class YieldGenerator(Maker):
         if cjorder.cj_addr in self.tx_unconfirm_timestamp:
             confirm_time = int(time.time()) - self.tx_unconfirm_timestamp[
                 cjorder.cj_addr]
+            del self.tx_unconfirm_timestamp[cjorder.cj_addr]
         else:
             confirm_time = 0
-        del self.tx_unconfirm_timestamp[cjorder.cj_addr]
         timestamp = datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")
         self.log_statement([timestamp, cjorder.cj_amount, len(
             cjorder.utxos), sum([av['value'] for av in cjorder.utxos.values(


### PR DESCRIPTION
One edit that moves a line into the if statement.

Aside: How does it happen that maker's don't see the unconfirmed transaction sometimes? It gets relayed to the miners but not to us for some reason.