### PR TITLE
BitcoinCoreInterface now guarentees that unconfirmfun() will always b…

### DIFF
--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -144,16 +144,9 @@ class BlockrInterface(BlockchainInterface):
                     blockr_url = 'https://' + self.blockr_domain
                     blockr_url += '.blockr.io/api/v1/address/txs/'
 
-                    # print 'downloading, lastusedaddr = ' + last_used_addr +
-                    #  ' unusedaddrcount= ' + str(unused_addr_count)
-
                     res = btc.make_request(blockr_url + ','.join(addrs))
                     data = json.loads(res)['data']
                     for dat in data:
-                        # todo: remove these commented out code sections
-                        # if forchange == 0: print ' nbtxs ' + str(dat[
-                        # 'nb_txs']) + ' addr=' + dat['address'] + ' unused='
-                        # + str(unused_addr_count)
                         if dat['nb_txs'] != 0:
                             last_used_addr = dat['address']
                             unused_addr_count = 0
@@ -406,11 +399,13 @@ class NotifyRequestHeader(BaseHTTPServer.BaseHTTPRequestHandler):
             tx_output_set = set([(sv['script'], sv['value']) for sv in txd[
                 'outs']])
 
-            unconfirmfun, confirmfun = None, None
-            for tx_out, ucfun, cfun in self.btcinterface.txnotify_fun:
+            txnotify_tuple = None
+            unconfirmfun, confirmfun, uc_called = None, None, None
+            for tnf in self.btcinterface.txnotify_fun:
+                tx_out = tnf[0]
                 if tx_out == tx_output_set:
-                    unconfirmfun = ucfun
-                    confirmfun = cfun
+                    txnotify_tuple = tnf
+                    tx_out, unconfirmfun, confirmfun, uc_called = tnf
                     break
             if unconfirmfun is None:
                 log.debug('txid=' + txid + ' not being listened for')
@@ -429,11 +424,17 @@ class NotifyRequestHeader(BaseHTTPServer.BaseHTTPRequestHandler):
                     # wallet_name = self.get_wallet_name()
                     # amount =
                     # bitcoin-cli move wallet_name "" amount
+                    self.btcinterface.txnotify_fun.remove(txnotify_tuple)
+                    self.btcinterface.txnotify_fun.append(txnotify_tuple[:-1]
+                        + (True,))
                     log.debug('ran unconfirmfun')
                 else:
+                    if not uc_called:
+                        unconfirmfun(txd, txid)
+                        log.debug('saw confirmed tx before unconfirmed, ' +
+                            'running unconfirmfun first')
                     confirmfun(txd, txid, txdata['confirmations'])
-                    self.btcinterface.txnotify_fun.remove(
-                            (tx_out, unconfirmfun, confirmfun))
+                    self.btcinterface.txnotify_fun.remove(txnotify_tuple)
                     log.debug('ran confirmfun')
 
         elif self.path.startswith('/alertnotify?'):
@@ -481,9 +482,6 @@ class BitcoinCoreNotifyThread(threading.Thread):
 # -walletnotify="curl -sI --connect-timeout 1 http://localhost:62602/walletnotify?%s"
 # and make sure curl is installed (git uses it, odds are you've already got it)
 
-
-# TODO must add the tx addresses as watchonly if case we ever broadcast a tx
-# with addresses not belonging to us
 class BitcoinCoreInterface(BlockchainInterface):
     def __init__(self, jsonRpc, network):
         super(BitcoinCoreInterface, self).__init__()
@@ -650,7 +648,7 @@ class BitcoinCoreInterface(BlockchainInterface):
         if not one_addr_imported:
             self.rpc('importaddress', [notifyaddr, 'joinmarket-notify', False])
         tx_output_set = set([(sv['script'], sv['value']) for sv in txd['outs']])
-        self.txnotify_fun.append((tx_output_set, unconfirmfun, confirmfun))
+        self.txnotify_fun.append((tx_output_set, unconfirmfun, confirmfun, False))
 
     def pushtx(self, txhex):
         try:


### PR DESCRIPTION
…e invoked, issue #436 

How this works: The list txnotify_fun now has elements which are 4-tuples instead of 3-tuples. The added tuple element is a boolean that remembers whether unconfirmfun() has been called yet. If it hasn't when the confirmed transaction is seen then call it.

Merging into develop this time. Please test. One thing that can be done is editing the True/False boolean part to make it as if unconfirmfun() hadn't been called yet.