### PR TITLE
maker_timeout_sec is readjusted for the second stage (!tx sending) ba…

### DIFF
--- a/joinmarket/__init__.py
+++ b/joinmarket/__init__.py
@@ -7,7 +7,7 @@ from .support import get_log, calc_cj_fee, debug_dump_object, \
     pick_order, cheapest_order_choose, weighted_order_choose, \
     rand_norm_array, rand_pow_array, rand_exp_array, joinmarket_alert, core_alert
 from .enc_wrapper import decode_decrypt, encrypt_encode, get_pubkey
-from .irc import IRCMessageChannel, random_nick
+from .irc import IRCMessageChannel, random_nick, B_PER_SEC
 from .jsonrpc import JsonRpcError, JsonRpcConnectionError, JsonRpc
 from .maker import Maker
 from .message_channel import MessageChannel


### PR DESCRIPTION
…sed on transaction size, and IRC throttling variables are module vars

Tested against regtest.py and tumbler-test.py OK (latter: 17 transactions with 3-7 counterparties). Made some manual checks of correct calculation (base maker timeout sec + 1.8\*Ncounterparties\*tx_size)

Also ran a test with 11 counterparties on regtest just to sanity check the size of the extra timeout (in that case it was bumped by 120 seconds). throttling and the timeout all seemed to be OK.