### PR TITLE
Wallet history

### DIFF
--- a/joinmarket/jsonrpc.py
+++ b/joinmarket/jsonrpc.py
@@ -114,7 +114,6 @@ class JsonRpc(object):
             raise JsonRpcConnectionError("invalid id returned by query")
 
         if response["error"] is not None:
-            print(response["error"])
             raise JsonRpcError(response["error"])
 
         return response["result"]

--- a/patientsendpayment.py
+++ b/patientsendpayment.py
@@ -140,7 +140,11 @@ def main():
             description='Sends a payment from your wallet to an given address' +
                         ' using coinjoin. First acts as a maker, announcing an order and ' +
                         'waiting for someone to fill it. After a set period of time, gives' +
-                        ' up waiting and acts as a taker and coinjoins any remaining coins')
+                        ' up waiting and acts as a taker and coinjoins any remaining coins.' +
+                        ' NOTE: In the current state of JoinMarket software, this script' +
+                        ' only works if your JoinMarket wallet contains the private key of your' +
+                        ' destination address. So you can only send to yourself and you need' +
+                        ' to import the privkey')
     parser.add_option(
             '-f',
             '--txfee',

--- a/sendpayment.py
+++ b/sendpayment.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 from __future__ import absolute_import
 
+import random
 import sys
 import threading
 from optparse import OptionParser
@@ -223,8 +224,8 @@ def main():
                       action='store',
                       type='int',
                       dest='makercount',
-                      help='how many makers to coinjoin with, default=2',
-                      default=2)
+                      help='how many makers to coinjoin with, default random from 2 to 4',
+                      default=random.randint(2, 4))
     parser.add_option(
         '-C',
         '--choose-cheapest',


### PR DESCRIPTION
Implementation of #200 

You need to be configured to use Bitcoin Core (-txindex=1 not required), run it with:

`python wallet-tool.py wallet.json history`

Prints a summary for every transaction. If you have numpy/scipy installed it also calculates the effective interest rate you achieved as if yield-generators were a savings account. For my own yield generator wallet the figure is 0.67% per annum

It checks if the amount of bitcoins in the wallet is the same as the resulting amount when added up as iterating through all transactions. It also checks if the number of UTXOs in the wallet match the number found by iterating through transactions. Both these checks fail for me, and I can't figure out why.

You can create a csv file for opening with spreadsheet software too:

`python wallet-tool.py --csv wallet.json history >> history.csv`