### PR TITLE
New re-integration of secp256k1 via ludbb binding; no longer using

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,26 @@ Widespread use of JoinMarket could improve bitcoin's fungibility as a commodity.
     make check
     sudo make install
     ```
++ (optional, recommended): Install the libsecp256k1 Python library:
 
+    ```
+    pip install secp256k1
+    ```
+
+ Note that this requires `pip`. This library will make use of libsecp256k1 if you already have it installed on your system. Most likely you won't, and it will try to build libsecp256k1 automatically for you. This requires some development packages; please read the installation details [here](https://github.com/ludbb/secp256k1-py#installation), provided for Debian/Ubuntu and OS X. Please also note that if you can't complete this step, Joinmarket will still run correctly, with two disadvantages: wallet loading is much slower without libsecp256k1, and the ECC crypto code is far less robust and well tested.
 + Matplotlib for displaying the graphs in orderbook-watcher (optional)
 
 ###DEBIAN / UBUNTU QUICK INSTALL FOR USERS:
 
 1. `sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install python libsodium-dev -y`
+2. `pip install secp256k1` (optional but recommended)
 2. `sudo apt-get install python-matplotlib -y` (optional)
-3. Download JoinMarket 0.1.2 source from [here](https://github.com/joinmarket-org/joinmarket/releases/tag/v0.1.3)
-4. Extract or unzip and `cd joinmarket-0.1.2`
+3. Download JoinMarket 0.1.3 source from [here](https://github.com/joinmarket-org/joinmarket/releases/tag/v0.1.3)
+4. Extract or unzip and `cd joinmarket-0.1.3`
 4. Generating your first wallet will populate the configuration file: `joinmarket.cfg`.
    Check if the default settings suit your needs.
 
-###[INSTALL FOR WINDOWS USERS](https://github.com/joinmarket-org/joinmarket/wiki/Installing-JoinMarket-on-Windows-7-(temporary))
+###[INSTALL FOR WINDOWS USERS](https://github.com/JoinMarket-Org/joinmarket/wiki/Installing-JoinMarket-on-Windows)
 
 ###[WIKI PAGES FOR DETAILED ARTICLES/GUIDES](https://github.com/joinmarket-org/joinmarket/wiki)
 
@@ -53,24 +60,20 @@ Clone the repo, then read the notes [here](./CONTRIBUTING.md).
 
 ###TESTING
 
-Install the developement requirements:
+Install the development requirements:
 
-    ```
     pip install -r requirements-dev.txt
-    ```
 
 Run the tests:
 
-    ```
     PYTHONPATH=.:$PYTHONPATH py.test
-    ```
 
 Generating html code coverage reports:
 
-    ```
-    PYTHONPATH=.:$PYTHONPATH py.test --cov-report html
+    PYTHONPATH=.:$PYTHONPATH py.test --cov-report html --btcroot=/path/to/bitcoin/bin/ --btcconf=/path/to/bitcoin.conf --btcpwd=123456abcdef
     open htmlcov/index.html
-    ```
+
+See more information on testing in the [Wiki page](https://github.com/JoinMarket-Org/joinmarket/wiki/Testing)
 
 ---
 

--- a/bitcoin/__init__.py
+++ b/bitcoin/__init__.py
@@ -1,6 +1,14 @@
 from bitcoin.py2specials import *
 from bitcoin.py3specials import *
-from bitcoin.main import *
-from bitcoin.transaction import *
-from bitcoin.deterministic import *
+secp_present = False
+try:
+    import secp256k1
+    secp_present = True
+    from bitcoin.secp256k1_main import *
+    from bitcoin.secp256k1_transaction import *
+    from bitcoin.secp256k1_deterministic import *    
+except ImportError:
+    from bitcoin.main import *
+    from bitcoin.deterministic import *
+    from bitcoin.transaction import *
 from bitcoin.bci import *

--- a/bitcoin/secp256k1_deterministic.py
+++ b/bitcoin/secp256k1_deterministic.py
@@ -1,0 +1,105 @@
+from bitcoin.secp256k1_main import *
+import hmac
+import hashlib
+from binascii import hexlify
+
+# Below code ASSUMES binary inputs and compressed pubkeys
+MAINNET_PRIVATE = b'\x04\x88\xAD\xE4'
+MAINNET_PUBLIC = b'\x04\x88\xB2\x1E'
+TESTNET_PRIVATE = b'\x04\x35\x83\x94'
+TESTNET_PUBLIC = b'\x04\x35\x87\xCF'
+PRIVATE = [MAINNET_PRIVATE, TESTNET_PRIVATE]
+PUBLIC = [MAINNET_PUBLIC, TESTNET_PUBLIC]
+
+# BIP32 child key derivation
+
+
+def raw_bip32_ckd(rawtuple, i):
+    vbytes, depth, fingerprint, oldi, chaincode, key = rawtuple
+    i = int(i)
+
+    if vbytes in PRIVATE:
+        priv = key
+        pub = privtopub(key, False)
+    else:
+        pub = key
+
+    if i >= 2**31:
+        if vbytes in PUBLIC:
+            raise Exception("Can't do private derivation on public key!")
+        I = hmac.new(chaincode, b'\x00' + priv[:32] + encode(i, 256, 4),
+                     hashlib.sha512).digest()
+    else:
+        I = hmac.new(chaincode, pub + encode(i, 256, 4),
+                     hashlib.sha512).digest()
+
+    if vbytes in PRIVATE:
+        newkey = add_privkeys(I[:32] + B'\x01', priv, False)
+        fingerprint = bin_hash160(privtopub(key, False))[:4]
+    if vbytes in PUBLIC:
+        newkey = add_pubkeys([privtopub(I[:32] + '\x01', False), key], False)
+        fingerprint = bin_hash160(key)[:4]
+
+    return (vbytes, depth + 1, fingerprint, i, I[32:], newkey)
+
+
+def bip32_serialize(rawtuple):
+    vbytes, depth, fingerprint, i, chaincode, key = rawtuple
+    i = encode(i, 256, 4)
+    chaincode = encode(hash_to_int(chaincode), 256, 32)
+    keydata = b'\x00' + key[:-1] if vbytes in PRIVATE else key
+    bindata = vbytes + from_int_to_byte(
+        depth % 256) + fingerprint + i + chaincode + keydata
+    return changebase(bindata + bin_dbl_sha256(bindata)[:4], 256, 58)
+
+
+def bip32_deserialize(data):
+    dbin = changebase(data, 58, 256)
+    if bin_dbl_sha256(dbin[:-4])[:4] != dbin[-4:]:
+        raise Exception("Invalid checksum")
+    vbytes = dbin[0:4]
+    depth = from_byte_to_int(dbin[4])
+    fingerprint = dbin[5:9]
+    i = decode(dbin[9:13], 256)
+    chaincode = dbin[13:45]
+    key = dbin[46:78] + b'\x01' if vbytes in PRIVATE else dbin[45:78]
+    return (vbytes, depth, fingerprint, i, chaincode, key)
+
+
+def raw_bip32_privtopub(rawtuple):
+    vbytes, depth, fingerprint, i, chaincode, key = rawtuple
+    newvbytes = MAINNET_PUBLIC if vbytes == MAINNET_PRIVATE else TESTNET_PUBLIC
+    return (newvbytes, depth, fingerprint, i, chaincode, privtopub(key, False))
+
+
+def bip32_privtopub(data):
+    return bip32_serialize(raw_bip32_privtopub(bip32_deserialize(data)))
+
+
+def bip32_ckd(data, i):
+    return bip32_serialize(raw_bip32_ckd(bip32_deserialize(data), i))
+
+
+def bip32_master_key(seed, vbytes=MAINNET_PRIVATE):
+    I = hmac.new(
+        from_string_to_bytes("Bitcoin seed"), seed, hashlib.sha512).digest()
+    return bip32_serialize((vbytes, 0, b'\x00' * 4, 0, I[32:], I[:32] + b'\x01'
+                           ))
+
+
+def bip32_bin_extract_key(data):
+    return bip32_deserialize(data)[-1]
+
+
+def bip32_extract_key(data):
+    return safe_hexlify(bip32_deserialize(data)[-1])
+
+
+def bip32_descend(*args):
+    if len(args) == 2:
+        key, path = args
+    else:
+        key, path = args[0], map(int, args[1:])
+    for p in path:
+        key = bip32_ckd(key, p)
+    return bip32_extract_key(key)

--- a/bitcoin/secp256k1_main.py
+++ b/bitcoin/secp256k1_main.py
@@ -116,20 +116,22 @@ pubtoaddr = pubkey_to_address
 def wif_compressed_privkey(priv, vbyte=0):
     """Convert privkey in hex compressed to WIF compressed
     """
-    if len(priv) != 33:
+    if len(priv) != 66:
         raise Exception("Wrong length of compressed private key")
-    if priv[-1] != '\x01':
+    if priv[-2:] != '01':
         raise Exception("Private key has wrong compression byte")
     return bin_to_b58check(binascii.unhexlify(priv), 128 + int(vbyte))
 
 
 def from_wif_privkey(wif_priv, compressed=True, vbyte=0):
-    """Convert WIF compressed privkey to hex compressed
+    """Convert WIF compressed privkey to hex compressed.
+    Caller specifies the network version byte (0 for mainnet, 0x6f
+    for testnet) that the key should correspond to; if there is
+    a mismatch an error is thrown. WIF encoding uses 128+ this number.
     """
     bin_key = b58check_to_bin(wif_priv)
-    print "got this binkey: " + binascii.hexlify(bin_key)
     claimed_version_byte = get_version_byte(wif_priv)
-    if not vbyte == claimed_version_byte:
+    if not 128+vbyte == claimed_version_byte:
         raise Exception(
             "WIF key version byte is wrong network (mainnet/testnet?)")
     if compressed and not len(bin_key) == 33:

--- a/bitcoin/secp256k1_main.py
+++ b/bitcoin/secp256k1_main.py
@@ -1,0 +1,406 @@
+#!/usr/bin/python
+from .py2specials import *
+from .py3specials import *
+import binascii
+import hashlib
+import re
+import sys
+import os
+import base64
+import time
+import random
+import hmac
+from bitcoin.ripemd import *
+import secp256k1
+
+ctx = secp256k1.lib.secp256k1_context_create(secp256k1.ALL_FLAGS)
+
+def privkey_to_address(priv, from_hex=True, magicbyte=0):
+    return pubkey_to_address(privkey_to_pubkey(priv, from_hex), magicbyte)
+
+privtoaddr = privkey_to_address
+
+# Hashes
+def bin_hash160(string):
+    intermed = hashlib.sha256(string).digest()
+    digest = ''
+    try:
+        digest = hashlib.new('ripemd160', intermed).digest()
+    except:
+        digest = RIPEMD160(intermed).digest()
+    return digest
+
+def hash160(string):
+    return safe_hexlify(bin_hash160(string))
+
+def bin_sha256(string):
+    binary_data = string if isinstance(string, bytes) else bytes(string,
+                                                                 'utf-8')
+    return hashlib.sha256(binary_data).digest()
+
+def sha256(string):
+    return bytes_to_hex_string(bin_sha256(string))
+
+def bin_ripemd160(string):
+    try:
+        digest = hashlib.new('ripemd160', string).digest()
+    except:
+        digest = RIPEMD160(string).digest()
+    return digest
+
+def ripemd160(string):
+    return safe_hexlify(bin_ripemd160(string))
+
+def bin_dbl_sha256(s):
+    bytes_to_hash = from_string_to_bytes(s)
+    return hashlib.sha256(hashlib.sha256(bytes_to_hash).digest()).digest()
+
+def dbl_sha256(string):
+    return safe_hexlify(bin_dbl_sha256(string))
+
+def bin_slowsha(string):
+    string = from_string_to_bytes(string)
+    orig_input = string
+    for i in range(100000):
+        string = hashlib.sha256(string + orig_input).digest()
+    return string
+
+def slowsha(string):
+    return safe_hexlify(bin_slowsha(string))
+
+def hash_to_int(x):
+    if len(x) in [40, 64]:
+        return decode(x, 16)
+    return decode(x, 256)
+
+def num_to_var_int(x):
+    x = int(x)
+    if x < 253: return from_int_to_byte(x)
+    elif x < 65536: return from_int_to_byte(253) + encode(x, 256, 2)[::-1]
+    elif x < 4294967296: return from_int_to_byte(254) + encode(x, 256, 4)[::-1]
+    else: return from_int_to_byte(255) + encode(x, 256, 8)[::-1]
+
+# WTF, Electrum?
+def electrum_sig_hash(message):
+    padded = b"\x18Bitcoin Signed Message:\n" + num_to_var_int(len(
+        message)) + from_string_to_bytes(message)
+    return bin_dbl_sha256(padded)
+
+# Encodings
+def b58check_to_bin(inp):
+    leadingzbytes = len(re.match('^1*', inp).group(0))
+    data = b'\x00' * leadingzbytes + changebase(inp, 58, 256)
+    assert bin_dbl_sha256(data[:-4])[:4] == data[-4:]
+    return data[1:-4]
+
+def get_version_byte(inp):
+    leadingzbytes = len(re.match('^1*', inp).group(0))
+    data = b'\x00' * leadingzbytes + changebase(inp, 58, 256)
+    assert bin_dbl_sha256(data[:-4])[:4] == data[-4:]
+    return ord(data[0])
+
+def hex_to_b58check(inp, magicbyte=0):
+    return bin_to_b58check(binascii.unhexlify(inp), magicbyte)
+
+def b58check_to_hex(inp):
+    return safe_hexlify(b58check_to_bin(inp))
+
+def pubkey_to_address(pubkey, magicbyte=0):
+    if len(pubkey) in [66, 130]:
+        return bin_to_b58check(
+            bin_hash160(binascii.unhexlify(pubkey)), magicbyte)
+    return bin_to_b58check(bin_hash160(pubkey), magicbyte)
+
+pubtoaddr = pubkey_to_address
+
+def wif_compressed_privkey(priv, vbyte=0):
+    """Convert privkey in hex compressed to WIF compressed
+    """
+    if len(priv) != 33:
+        raise Exception("Wrong length of compressed private key")
+    if priv[-1] != '\x01':
+        raise Exception("Private key has wrong compression byte")
+    return bin_to_b58check(binascii.unhexlify(priv), 128 + int(vbyte))
+
+
+def from_wif_privkey(wif_priv, compressed=True, vbyte=0):
+    """Convert WIF compressed privkey to hex compressed
+    """
+    bin_key = b58check_to_bin(wif_priv)
+    print "got this binkey: " + binascii.hexlify(bin_key)
+    claimed_version_byte = get_version_byte(wif_priv)
+    if not vbyte == claimed_version_byte:
+        raise Exception(
+            "WIF key version byte is wrong network (mainnet/testnet?)")
+    if compressed and not len(bin_key) == 33:
+        raise Exception("Compressed private key is not 33 bytes")
+    if compressed and not bin_key[-1] == '\x01':
+        raise Exception("Private key has incorrect compression byte")
+    return safe_hexlify(bin_key)
+
+def ecdsa_sign(msg, priv, usehex=True):
+    #Compatibility issue: old bots will be confused
+    #by different msg hashing algo; need to keep electrum_sig_hash, temporarily.
+    hashed_msg = electrum_sig_hash(msg)
+    if usehex:
+        #arguments to raw sign must be consistently hex or bin
+        hashed_msg = binascii.hexlify(hashed_msg)
+    dersig = ecdsa_raw_sign(hashed_msg, priv, usehex, rawmsg=True)
+    #see comments to legacy* functions
+    #also, note those functions only handles binary, not hex
+    if usehex:
+        dersig = binascii.unhexlify(dersig)
+    sig = legacy_ecdsa_sign_convert(dersig)
+    return base64.b64encode(sig)
+
+def ecdsa_verify(msg, sig, pub, usehex=True):
+    #See note to ecdsa_sign
+    hashed_msg = electrum_sig_hash(msg)
+    sig = base64.b64decode(sig)
+    #see comments to legacy* functions
+    sig = legacy_ecdsa_verify_convert(sig)
+    if not sig:
+        print 'legacy returned false'
+        return False
+    if usehex:
+        #arguments to raw_verify must be consistently hex or bin
+        hashed_msg = binascii.hexlify(hashed_msg)
+        sig = binascii.hexlify(sig)
+    return ecdsa_raw_verify(hashed_msg, pub, sig, usehex, rawmsg=True)
+
+#A sadly necessary hack until all joinmarket bots are running secp256k1 code.
+#pybitcointools *message* signatures (not transaction signatures) used an old signature
+#format, basically: [27+y%2] || 32 byte r || 32 byte s,
+#instead of DER. These two functions translate the new version into the old so that
+#counterparty bots can verify successfully.
+def legacy_ecdsa_sign_convert(dersig):
+    #note there is no sanity checking of DER format (e.g. leading length byte)
+    dersig = dersig[2:]  #e.g. 3045
+    rlen = ord(dersig[1])  #ignore leading 02
+    #length of r and s: ALWAYS <=33, USUALLY >=32 but can be shorter
+    if rlen > 33:
+        raise Exception("Incorrectly formatted DER sig:" + binascii.hexlify(
+            dersig))
+    if dersig[2] == '\x00':
+        r = dersig[3:2 + rlen]
+        ssig = dersig[2 + rlen:]
+    else:
+        r = dersig[2:2 + rlen]
+        ssig = dersig[2 + rlen:]
+
+    slen = ord(ssig[1])  #ignore leading 02
+    if slen > 33:
+        raise Exception("Incorrectly formatted DER sig:" + binascii.hexlify(
+            dersig))
+    if len(ssig) != 2 + slen:
+        raise Exception("Incorrectly formatted DER sig:" + binascii.hexlify(
+            dersig))
+    if ssig[2] == '\x00':
+        s = ssig[3:2 + slen]
+    else:
+        s = ssig[2:2 + slen]
+
+        #the legacy version requires padding of r and s to 32 bytes with leading zeros
+    r = '\x00' * (32 - len(r)) + r
+    s = '\x00' * (32 - len(s)) + s
+
+    #note: in the original pybitcointools implementation,
+    #verification ignored the leading byte (it's only needed for pubkey recovery)
+    #so we just ignore parity here.
+    return chr(27) + r + s
+
+def legacy_ecdsa_verify_convert(sig):
+    sig = sig[1:]  #ignore parity byte
+    try:
+        r, s = sig[:32], sig[32:]
+    except:
+        #signature is invalid.
+        return False
+    if not len(s) == 32:
+        #signature is invalid.
+        return False
+    #legacy code can produce high S. Need to reintroduce N ::cry::
+    N = 115792089237316195423570985008687907852837564279074904382605163141518161494337
+    s_int = decode(s, 256)
+    # note // is integer division operator in both 2.7 and 3
+    s_int = N - s_int if s_int > N // 2 else s_int  #enforce low S.
+
+    #on re-encoding, don't use the minlen parameter, because
+    #DER does not used fixed (32 byte) length values, so we
+    #don't prepend zero bytes to shorter numbers.
+    s = encode(s_int, 256)
+
+    #as above, remove any front zero padding from r.
+    r = encode(decode(r, 256), 256)
+
+    #canonicalize r and s
+    r, s = ['\x00' + x if ord(x[0]) > 127 else x for x in [r, s]]
+    rlen = chr(len(r))
+    slen = chr(len(s))
+    total_len = 2 + len(r) + 2 + len(s)
+    return '\x30' + chr(total_len) + '\x02' + rlen + r + '\x02' + slen + s
+
+#Use secp256k1 to handle all EC and ECDSA operations.
+#Data types: only hex and binary.
+#Compressed and uncompressed private and public keys.
+def hexbin(func):
+    '''To enable each function to 'speak' either hex or binary,
+    requires that the decorated function's final positional argument
+    is a boolean flag, True for hex and False for binary.
+    '''
+
+    def func_wrapper(*args, **kwargs):
+        if args[-1]:
+            newargs = []
+            for arg in args[:-1]:
+                if isinstance(arg, (list, tuple)):
+                    newargs += [[x.decode('hex') for x in arg]]
+                else:
+                    newargs += [arg.decode('hex')]
+            newargs += [False]
+            returnval = func(*newargs, **kwargs)
+            if isinstance(returnval, bool):
+                return returnval
+            else:
+                return binascii.hexlify(returnval)
+        else:
+            return func(*args, **kwargs)
+
+    return func_wrapper
+
+def read_privkey(priv):
+    if len(priv) == 33:
+        if priv[-1] == '\x01':
+            compressed = True
+        else:
+            raise Exception("Invalid private key")
+    elif len(priv) == 32:
+        compressed = False
+    else:
+        raise Exception("Invalid private key")
+    return (compressed, priv[:32])
+
+@hexbin
+def privkey_to_pubkey_inner(priv, usehex):
+    '''Take 32/33 byte raw private key as input.
+    If 32 bytes, return compressed (33 byte) raw public key.
+    If 33 bytes, read the final byte as compression flag,
+    and return compressed/uncompressed public key as appropriate.'''
+    compressed, priv = read_privkey(priv)
+    #secp256k1 checks for validity of key value.
+    newpriv = secp256k1.PrivateKey(privkey=priv, ctx=ctx)
+    return newpriv.pubkey.serialize(compressed=compressed)
+
+def privkey_to_pubkey(priv, usehex=True):
+    '''To avoid changing the interface from the legacy system,
+    allow an *optional* hex argument here (called differently from
+    maker/taker code to how it's called in bip32 code), then
+    pass to the standard hexbin decorator under the hood.
+    '''
+    return privkey_to_pubkey_inner(priv, usehex)
+
+privtopub = privkey_to_pubkey
+
+@hexbin
+def multiply(s, pub, usehex, rawpub=True):
+    '''Input binary compressed pubkey P(33 bytes)
+    and scalar s(32 bytes), return s*P.
+    The return value is a binary compressed public key.
+    Note that the called function does the type checking
+    of the scalar s.
+    ('raw' options passed in)
+    '''
+    newpub = secp256k1.PublicKey(pub, raw=rawpub, ctx=ctx)
+    res = newpub.tweak_mul(s)
+    return res.serialize()
+
+@hexbin
+def add_pubkeys(pubkeys, usehex):
+    '''Input a list of binary compressed pubkeys
+    and return their sum as a binary compressed pubkey.'''
+    r = secp256k1.PublicKey(ctx=ctx)  #dummy holding object
+    pubkey_list = [secp256k1.PublicKey(x,
+                                       raw=True,
+                                       ctx=ctx).public_key for x in pubkeys]
+    r.combine(pubkey_list)
+    return r.serialize()
+
+@hexbin
+def add_privkeys(priv1, priv2, usehex):
+    '''Add privkey 1 to privkey 2.
+    Input keys must be in binary either compressed or not.
+    Returned key will have the same compression state.
+    Error if compression state of both input keys is not the same.'''
+    y, z = [read_privkey(x) for x in [priv1, priv2]]
+    if y[0] != z[0]:
+        raise Exception("cannot add privkeys, mixed compression formats")
+    else:
+        compressed = y[0]
+    newpriv1, newpriv2 = (y[1], z[1])
+    p1 = secp256k1.PrivateKey(newpriv1, raw=True, ctx=ctx)
+    res = p1.tweak_add(newpriv2)
+    if compressed:
+        res += '\x01'
+    return res
+
+@hexbin
+def ecdsa_raw_sign(msg,
+                   priv,
+                   usehex,
+                   rawpriv=True,
+                   rawmsg=False,
+                   usenonce=None):
+    '''Take the binary message msg and sign it with the private key
+    priv.
+    By default priv is just a 32 byte string, if rawpriv is false
+    it is assumed to be DER encoded.
+    If rawmsg is True, no sha256 hash is applied to msg before signing.
+    In this case, msg must be a precalculated hash (256 bit).
+    If rawmsg is False, the secp256k1 lib will hash the message as part
+    of the ECDSA-SHA256 signing algo.
+    If usenonce is not None, its value is passed to the secp256k1 library
+    sign() function as the ndata value, which is then used in conjunction
+    with a custom nonce generating function, such that the nonce used in the ECDSA
+    sign algorithm is exactly that value (ndata there, usenonce here). 32 bytes.
+    Return value: the calculated signature.'''
+    if rawmsg and len(msg) != 32:
+        raise Exception("Invalid hash input to ECDSA raw sign.")
+    if rawpriv:
+        compressed, p = read_privkey(priv)
+        newpriv = secp256k1.PrivateKey(p, raw=True, ctx=ctx)
+    else:
+        newpriv = secp256k1.PrivateKey(priv, raw=False, ctx=ctx)
+    if usenonce and len(usenonce) != 32:
+        raise ValueError("Invalid nonce passed to ecdsa_sign: " + str(usenonce))
+
+    sig = newpriv.ecdsa_sign(msg, raw=rawmsg)
+    return newpriv.ecdsa_serialize(sig)
+
+@hexbin
+def ecdsa_raw_verify(msg, pub, sig, usehex, rawmsg=False):
+    '''Take the binary message msg and binary signature sig,
+    and verify it against the pubkey pub.
+    If rawmsg is True, no sha256 hash is applied to msg before verifying.
+    In this case, msg must be a precalculated hash (256 bit).
+    If rawmsg is False, the secp256k1 lib will hash the message as part
+    of the ECDSA-SHA256 verification algo.
+    Return value: True if the signature is valid for this pubkey, False
+    otherwise. '''
+    if rawmsg and len(msg) != 32:
+        raise Exception("Invalid hash input to ECDSA raw sign.")
+    newpub = secp256k1.PublicKey(pubkey=pub, raw=True, ctx=ctx)
+    sigobj = newpub.ecdsa_deserialize(sig)
+    return newpub.ecdsa_verify(msg, sigobj, raw=rawmsg)
+
+def estimate_tx_size(ins, outs, txtype='p2pkh'):
+    '''Estimate transaction size.
+    Assuming p2pkh:
+    out: 8+1+3+2+20=34, in: 1+32+4+1+1+~73+1+1+33=147,
+    ver:4,seq:4, +2 (len in,out)
+    total ~= 34*len_out + 147*len_in + 10 (sig sizes vary slightly)
+    '''
+    if txtype == 'p2pkh':
+        return 10 + ins * 147 + 34 * outs
+    else:
+        raise NotImplementedError("Non p2pkh transaction size estimation not" +
+                                  "yet implemented")

--- a/bitcoin/secp256k1_transaction.py
+++ b/bitcoin/secp256k1_transaction.py
@@ -1,0 +1,474 @@
+#!/usr/bin/python
+import binascii, re, json, copy, sys
+from bitcoin.secp256k1_main import *
+from _functools import reduce
+import os
+
+### Hex to bin converter and vice versa for objects
+def json_is_base(obj, base):
+    if not is_python2 and isinstance(obj, bytes):
+        return False
+
+    alpha = get_code_string(base)
+    if isinstance(obj, string_types):
+        for i in range(len(obj)):
+            if alpha.find(obj[i]) == -1:
+                return False
+        return True
+    elif isinstance(obj, int_types) or obj is None:
+        return True
+    elif isinstance(obj, list):
+        for i in range(len(obj)):
+            if not json_is_base(obj[i], base):
+                return False
+        return True
+    else:
+        for x in obj:
+            if not json_is_base(obj[x], base):
+                return False
+        return True
+
+
+def json_changebase(obj, changer):
+    if isinstance(obj, string_or_bytes_types):
+        return changer(obj)
+    elif isinstance(obj, int_types) or obj is None:
+        return obj
+    elif isinstance(obj, list):
+        return [json_changebase(x, changer) for x in obj]
+    return dict((x, json_changebase(obj[x], changer)) for x in obj)
+
+# Transaction serialization and deserialization
+
+
+def deserialize(tx):
+    if isinstance(tx, str) and re.match('^[0-9a-fA-F]*$', tx):
+        #tx = bytes(bytearray.fromhex(tx))
+        return json_changebase(
+            deserialize(binascii.unhexlify(tx)), lambda x: safe_hexlify(x))
+    # http://stackoverflow.com/questions/4851463/python-closure-write-to-variable-in-parent-scope
+    # Python's scoping rules are demented, requiring me to make pos an object
+    # so that it is call-by-reference
+    pos = [0]
+
+    def read_as_int(bytez):
+        pos[0] += bytez
+        return decode(tx[pos[0] - bytez:pos[0]][::-1], 256)
+
+    def read_var_int():
+        pos[0] += 1
+
+        val = from_byte_to_int(tx[pos[0] - 1])
+        if val < 253:
+            return val
+        return read_as_int(pow(2, val - 252))
+
+    def read_bytes(bytez):
+        pos[0] += bytez
+        return tx[pos[0] - bytez:pos[0]]
+
+    def read_var_string():
+        size = read_var_int()
+        return read_bytes(size)
+
+    obj = {"ins": [], "outs": []}
+    obj["version"] = read_as_int(4)
+    ins = read_var_int()
+    for i in range(ins):
+        obj["ins"].append({
+            "outpoint": {
+                "hash": read_bytes(32)[::-1],
+                "index": read_as_int(4)
+            },
+            "script": read_var_string(),
+            "sequence": read_as_int(4)
+        })
+    outs = read_var_int()
+    for i in range(outs):
+        obj["outs"].append({
+            "value": read_as_int(8),
+            "script": read_var_string()
+        })
+    obj["locktime"] = read_as_int(4)
+    return obj
+
+
+def serialize(txobj):
+    #if isinstance(txobj, bytes):
+    #    txobj = bytes_to_hex_string(txobj)
+    o = []
+    if json_is_base(txobj, 16):
+        json_changedbase = json_changebase(txobj,
+                                           lambda x: binascii.unhexlify(x))
+        hexlified = safe_hexlify(serialize(json_changedbase))
+        return hexlified
+    o.append(encode(txobj["version"], 256, 4)[::-1])
+    o.append(num_to_var_int(len(txobj["ins"])))
+    for inp in txobj["ins"]:
+        o.append(inp["outpoint"]["hash"][::-1])
+        o.append(encode(inp["outpoint"]["index"], 256, 4)[::-1])
+        o.append(num_to_var_int(len(inp["script"])) + (inp["script"] if inp[
+            "script"] or is_python2 else bytes()))
+        o.append(encode(inp["sequence"], 256, 4)[::-1])
+    o.append(num_to_var_int(len(txobj["outs"])))
+    for out in txobj["outs"]:
+        o.append(encode(out["value"], 256, 8)[::-1])
+        o.append(num_to_var_int(len(out["script"])) + out["script"])
+    o.append(encode(txobj["locktime"], 256, 4)[::-1])
+
+    return ''.join(o) if is_python2 else reduce(lambda x, y: x + y, o, bytes())
+
+# Hashing transactions for signing
+
+SIGHASH_ALL = 1
+SIGHASH_NONE = 2
+SIGHASH_SINGLE = 3
+# this works like SIGHASH_ANYONECANPAY | SIGHASH_ALL, might as well make it explicit while
+# we fix the constant
+SIGHASH_ANYONECANPAY = 0x81
+
+
+def signature_form(tx, i, script, hashcode=SIGHASH_ALL):
+    i, hashcode = int(i), int(hashcode)
+    if isinstance(tx, string_or_bytes_types):
+        return serialize(signature_form(deserialize(tx), i, script, hashcode))
+    newtx = copy.deepcopy(tx)
+    for inp in newtx["ins"]:
+        inp["script"] = ""
+    newtx["ins"][i]["script"] = script
+    if hashcode == SIGHASH_NONE:
+        newtx["outs"] = []
+    elif hashcode == SIGHASH_SINGLE:
+        newtx["outs"] = newtx["outs"][:len(newtx["ins"])]
+        for out in range(len(newtx["ins"]) - 1):
+            out.value = 2**64 - 1
+            out.script = ""
+    elif hashcode == SIGHASH_ANYONECANPAY:
+        newtx["ins"] = [newtx["ins"][i]]
+    else:
+        pass
+    return newtx
+
+def txhash(tx, hashcode=None):
+    if isinstance(tx, str) and re.match('^[0-9a-fA-F]*$', tx):
+        tx = changebase(tx, 16, 256)
+    if hashcode:
+        return dbl_sha256(from_string_to_bytes(tx) + encode(
+            int(hashcode), 256, 4)[::-1])
+    else:
+        return safe_hexlify(bin_dbl_sha256(tx)[::-1])
+
+
+def bin_txhash(tx, hashcode=None):
+    return binascii.unhexlify(txhash(tx, hashcode))
+
+
+def ecdsa_tx_sign(tx, priv, hashcode=SIGHASH_ALL, usenonce=None):
+    sig = ecdsa_raw_sign(
+        txhash(tx, hashcode),
+        priv,
+        True,
+        rawmsg=True,
+        usenonce=usenonce)
+    return sig + encode(hashcode, 16, 2)
+
+
+def ecdsa_tx_verify(tx, sig, pub, hashcode=SIGHASH_ALL):
+    return ecdsa_raw_verify(
+        txhash(tx, hashcode),
+        pub,
+        sig[:-2],
+        True,
+        rawmsg=True)
+
+# Scripts
+
+
+def mk_pubkey_script(addr):
+    # Keep the auxiliary functions around for altcoins' sake
+    return '76a914' + b58check_to_hex(addr) + '88ac'
+
+
+def mk_scripthash_script(addr):
+    return 'a914' + b58check_to_hex(addr) + '87'
+
+# Address representation to output script
+
+
+def address_to_script(addr):
+    if addr[0] == '3' or addr[0] == '2':
+        return mk_scripthash_script(addr)
+    else:
+        return mk_pubkey_script(addr)
+
+# Output script to address representation
+
+
+def script_to_address(script, vbyte=0):
+    if re.match('^[0-9a-fA-F]*$', script):
+        script = binascii.unhexlify(script)
+    if script[:3] == b'\x76\xa9\x14' and script[-2:] == b'\x88\xac' and len(
+            script) == 25:
+        return bin_to_b58check(script[3:-2], vbyte)  # pubkey hash addresses
+    else:
+        if vbyte in [111, 196]:
+            # Testnet
+            scripthash_byte = 196
+        else:
+            scripthash_byte = 5
+        # BIP0016 scripthash addresses
+        return bin_to_b58check(script[2:-1], scripthash_byte)
+
+
+def p2sh_scriptaddr(script, magicbyte=5):
+    if re.match('^[0-9a-fA-F]*$', script):
+        script = binascii.unhexlify(script)
+    return hex_to_b58check(hash160(script), magicbyte)
+
+
+scriptaddr = p2sh_scriptaddr
+
+
+def deserialize_script(script):
+    if isinstance(script, str) and re.match('^[0-9a-fA-F]*$', script):
+        return json_changebase(
+            deserialize_script(binascii.unhexlify(script)),
+            lambda x: safe_hexlify(x))
+    out, pos = [], 0
+    while pos < len(script):
+        code = from_byte_to_int(script[pos])
+        if code == 0:
+            out.append(None)
+            pos += 1
+        elif code <= 75:
+            out.append(script[pos + 1:pos + 1 + code])
+            pos += 1 + code
+        elif code <= 78:
+            szsz = pow(2, code - 76)
+            sz = decode(script[pos + szsz:pos:-1], 256)
+            out.append(script[pos + 1 + szsz:pos + 1 + szsz + sz])
+            pos += 1 + szsz + sz
+        elif code <= 96:
+            out.append(code - 80)
+            pos += 1
+        else:
+            out.append(code)
+            pos += 1
+    return out
+
+
+def serialize_script_unit(unit):
+    if isinstance(unit, int):
+        if unit < 16:
+            return from_int_to_byte(unit + 80)
+        else:
+            return bytes([unit])
+    elif unit is None:
+        return b'\x00'
+    else:
+        if len(unit) <= 75:
+            return from_int_to_byte(len(unit)) + unit
+        elif len(unit) < 256:
+            return from_int_to_byte(76) + from_int_to_byte(len(unit)) + unit
+        elif len(unit) < 65536:
+            return from_int_to_byte(77) + encode(len(unit), 256, 2)[::-1] + unit
+        else:
+            return from_int_to_byte(78) + encode(len(unit), 256, 4)[::-1] + unit
+
+
+if is_python2:
+
+    def serialize_script(script):
+        if json_is_base(script, 16):
+            return binascii.hexlify(serialize_script(json_changebase(
+                script, lambda x: binascii.unhexlify(x))))
+        return ''.join(map(serialize_script_unit, script))
+else:
+
+    def serialize_script(script):
+        if json_is_base(script, 16):
+            return safe_hexlify(serialize_script(json_changebase(
+                script, lambda x: binascii.unhexlify(x))))
+
+        result = bytes()
+        for b in map(serialize_script_unit, script):
+            result += b if isinstance(b, bytes) else bytes(b, 'utf-8')
+        return result
+
+
+def mk_multisig_script(*args):  # [pubs],k or pub1,pub2...pub[n],k
+    if isinstance(args[0], list):
+        pubs, k = args[0], int(args[1])
+    else:
+        pubs = list(filter(lambda x: len(str(x)) >= 32, args))
+        k = int(args[len(pubs)])
+    return serialize_script([k] + pubs + [len(pubs)]) + 'ae'
+
+# Signing and verifying
+
+
+def verify_tx_input(tx, i, script, sig, pub):
+    if re.match('^[0-9a-fA-F]*$', tx):
+        tx = binascii.unhexlify(tx)
+    if re.match('^[0-9a-fA-F]*$', script):
+        script = binascii.unhexlify(script)
+    if not re.match('^[0-9a-fA-F]*$', sig):
+        sig = safe_hexlify(sig)
+    if not re.match('^[0-9a-fA-F]*$', pub):
+        pub = safe_hexlify(pub)
+    hashcode = decode(sig[-2:], 16)
+    modtx = signature_form(tx, int(i), script, hashcode)
+    return ecdsa_tx_verify(modtx, sig, pub, hashcode)
+
+
+def sign(tx, i, priv, hashcode=SIGHASH_ALL, usenonce=None):
+    i = int(i)
+    if (not is_python2 and isinstance(re, bytes)) or not re.match(
+            '^[0-9a-fA-F]*$', tx):
+        return binascii.unhexlify(sign(safe_hexlify(tx), i, priv))
+    if len(priv) <= 33:
+        priv = safe_hexlify(priv)
+    pub = privkey_to_pubkey(priv, True)
+    address = pubkey_to_address(pub)
+    signing_tx = signature_form(tx, i, mk_pubkey_script(address), hashcode)
+    sig = ecdsa_tx_sign(signing_tx, priv, hashcode, usenonce=usenonce)
+    txobj = deserialize(tx)
+    txobj["ins"][i]["script"] = serialize_script([sig, pub])
+    return serialize(txobj)
+
+
+def signall(tx, priv):
+    # if priv is a dictionary, assume format is
+    # { 'txinhash:txinidx' : privkey }
+    if isinstance(priv, dict):
+        for e, i in enumerate(deserialize(tx)["ins"]):
+            k = priv["%s:%d" % (i["outpoint"]["hash"], i["outpoint"]["index"])]
+            tx = sign(tx, e, k)
+    else:
+        for i in range(len(deserialize(tx)["ins"])):
+            tx = sign(tx, i, priv)
+    return tx
+
+
+def multisign(tx, i, script, pk, hashcode=SIGHASH_ALL):
+    if re.match('^[0-9a-fA-F]*$', tx):
+        tx = binascii.unhexlify(tx)
+    if re.match('^[0-9a-fA-F]*$', script):
+        script = binascii.unhexlify(script)
+    modtx = signature_form(tx, i, script, hashcode)
+    return ecdsa_tx_sign(modtx, pk, hashcode)
+
+
+def apply_multisignatures(*args):
+    # tx,i,script,sigs OR tx,i,script,sig1,sig2...,sig[n]
+    tx, i, script = args[0], int(args[1]), args[2]
+    sigs = args[3] if isinstance(args[3], list) else list(args[3:])
+
+    if isinstance(script, str) and re.match('^[0-9a-fA-F]*$', script):
+        script = binascii.unhexlify(script)
+    sigs = [binascii.unhexlify(x) if x[:2] == '30' else x for x in sigs]
+    if isinstance(tx, str) and re.match('^[0-9a-fA-F]*$', tx):
+        return safe_hexlify(apply_multisignatures(
+            binascii.unhexlify(tx), i, script, sigs))
+
+    txobj = deserialize(tx)
+    txobj["ins"][i]["script"] = serialize_script([None] + sigs + [script])
+    return serialize(txobj)
+
+
+def is_inp(arg):
+    return len(arg) > 64 or "output" in arg or "outpoint" in arg
+
+
+def mktx(*args):
+    # [in0, in1...],[out0, out1...] or in0, in1 ... out0 out1 ...
+    ins, outs = [], []
+    for arg in args:
+        if isinstance(arg, list):
+            for a in arg:
+                (ins if is_inp(a) else outs).append(a)
+        else:
+            (ins if is_inp(arg) else outs).append(arg)
+
+    txobj = {"locktime": 0, "version": 1, "ins": [], "outs": []}
+    for i in ins:
+        if isinstance(i, dict) and "outpoint" in i:
+            txobj["ins"].append(i)
+        else:
+            if isinstance(i, dict) and "output" in i:
+                i = i["output"]
+            txobj["ins"].append({
+                "outpoint": {"hash": i[:64],
+                             "index": int(i[65:])},
+                "script": "",
+                "sequence": 4294967295
+            })
+    for o in outs:
+        if isinstance(o, string_or_bytes_types):
+            addr = o[:o.find(':')]
+            val = int(o[o.find(':') + 1:])
+            o = {}
+            if re.match('^[0-9a-fA-F]*$', addr):
+                o["script"] = addr
+            else:
+                o["address"] = addr
+            o["value"] = val
+
+        outobj = {}
+        if "address" in o:
+            outobj["script"] = address_to_script(o["address"])
+        elif "script" in o:
+            outobj["script"] = o["script"]
+        else:
+            raise Exception("Could not find 'address' or 'script' in output.")
+        outobj["value"] = o["value"]
+        txobj["outs"].append(outobj)
+
+    return serialize(txobj)
+
+
+def select(unspent, value):
+    value = int(value)
+    high = [u for u in unspent if u["value"] >= value]
+    high.sort(key=lambda u: u["value"])
+    low = [u for u in unspent if u["value"] < value]
+    low.sort(key=lambda u: -u["value"])
+    if len(high):
+        return [high[0]]
+    i, tv = 0, 0
+    while tv < value and i < len(low):
+        tv += low[i]["value"]
+        i += 1
+    if tv < value:
+        raise Exception("Not enough funds")
+    return low[:i]
+
+# Only takes inputs of the form { "output": blah, "value": foo }
+
+
+def mksend(*args):
+    argz, change, fee = args[:-2], args[-2], int(args[-1])
+    ins, outs = [], []
+    for arg in argz:
+        if isinstance(arg, list):
+            for a in arg:
+                (ins if is_inp(a) else outs).append(a)
+        else:
+            (ins if is_inp(arg) else outs).append(arg)
+
+    isum = sum([i["value"] for i in ins])
+    osum, outputs2 = 0, []
+    for o in outs:
+        if isinstance(o, string_types):
+            o2 = {"address": o[:o.find(':')], "value": int(o[o.find(':') + 1:])}
+        else:
+            o2 = o
+        outputs2.append(o2)
+        osum += o2["value"]
+
+    if isum < osum + fee:
+        raise Exception("Not enough money")
+    elif isum > osum + fee + 5430:
+        outputs2 += [{"address": change, "value": isum - osum - fee}]
+
+    return mktx(ins, outputs2)

--- a/create-unsigned-tx.py
+++ b/create-unsigned-tx.py
@@ -27,6 +27,7 @@ log = get_log()
 # thread which does the buy-side algorithm
 # chooses which coinjoins to initiate and when
 class PaymentThread(threading.Thread):
+
     def __init__(self, taker):
         threading.Thread.__init__(self, name='PaymentThread')
         self.daemon = True
@@ -35,8 +36,7 @@ class PaymentThread(threading.Thread):
 
     def create_tx(self):
         crow = self.taker.db.execute(
-                'SELECT COUNT(DISTINCT counterparty) FROM orderbook;'
-        ).fetchone()
+            'SELECT COUNT(DISTINCT counterparty) FROM orderbook;').fetchone()
 
         counterparty_count = crow['COUNT(DISTINCT counterparty)']
         counterparty_count -= len(self.ignored_makers)
@@ -51,9 +51,9 @@ class PaymentThread(threading.Thread):
         if self.taker.cjamount == 0:
             total_value = sum([va['value'] for va in utxos.values()])
             orders, cjamount, total_cj_fee = choose_sweep_orders(
-                    self.taker.db, total_value, self.taker.options.txfee,
-                    self.taker.options.makercount, self.taker.chooseOrdersFunc,
-                    self.ignored_makers)
+                self.taker.db, total_value, self.taker.options.txfee,
+                self.taker.options.makercount, self.taker.chooseOrdersFunc,
+                self.ignored_makers)
             if not self.taker.options.answeryes:
                 log.debug('total cj fee = ' + str(total_cj_fee))
                 total_fee_pc = 1.0 * total_cj_fee / cjamount
@@ -66,10 +66,10 @@ class PaymentThread(threading.Thread):
                     return
         else:
             orders, total_cj_fee = self.sendpayment_choose_orders(
-                    self.taker.cjamount, self.taker.options.makercount)
+                self.taker.cjamount, self.taker.options.makercount)
             if not orders:
                 log.debug(
-                        'ERROR not enough liquidity in the orderbook, exiting')
+                    'ERROR not enough liquidity in the orderbook, exiting')
                 return
             total_amount = self.taker.cjamount + total_cj_fee + \
                            self.taker.options.txfee
@@ -90,7 +90,7 @@ class PaymentThread(threading.Thread):
             tx = btc.serialize(coinjointx.latest_tx)
             for index, ins in enumerate(coinjointx.latest_tx['ins']):
                 utxo = ins['outpoint']['hash'] + ':' + str(ins['outpoint'][
-                                                               'index'])
+                    'index'])
                 if utxo != self.taker.auth_utxo:
                     continue
                 addr = coinjointx.input_utxos[utxo]['address']
@@ -101,8 +101,8 @@ class PaymentThread(threading.Thread):
             self.taker.msgchan.shutdown()
             return
         self.ignored_makers += coinjointx.nonrespondants
-        log.debug(
-                'recreating the tx, ignored_makers=' + str(self.ignored_makers))
+        log.debug('recreating the tx, ignored_makers=' + str(
+            self.ignored_makers))
         self.create_tx()
 
     def sendpayment_choose_orders(self,
@@ -116,13 +116,12 @@ class PaymentThread(threading.Thread):
             nonrespondants = []
         self.ignored_makers += nonrespondants
         orders, total_cj_fee = choose_orders(
-                self.taker.db, cj_amount, makercount,
-                self.taker.chooseOrdersFunc,
-                self.ignored_makers + active_nicks)
+            self.taker.db, cj_amount, makercount, self.taker.chooseOrdersFunc,
+            self.ignored_makers + active_nicks)
         if not orders:
             return None, 0
         print 'chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(
-                total_cj_fee)
+            total_cj_fee)
         if not self.taker.options.answeryes:
             if len(self.ignored_makers) > 0:
                 noun = 'total'
@@ -145,6 +144,7 @@ class PaymentThread(threading.Thread):
 
 
 class CreateUnsignedTx(takermodule.Taker):
+
     def __init__(self, msgchan, wallet, auth_utxo, cjamount, destaddr,
                  changeaddr, utxo_data, options, chooseOrdersFunc):
         takermodule.Taker.__init__(self, msgchan)
@@ -164,63 +164,60 @@ class CreateUnsignedTx(takermodule.Taker):
 
 def main():
     parser = OptionParser(
-            usage='usage: %prog [options] [auth utxo] [cjamount] [cjaddr] ['
-                  'changeaddr] [utxos..]',
-            description=('Creates an unsigned coinjoin transaction. Outputs '
-                         'a partially signed transaction hex string. The user '
-                         'must sign their inputs independently and broadcast '
-                         'them. The JoinMarket protocol requires the taker to '
-                         'have a single p2pk UTXO input to use to '
-                         'authenticate the  encrypted messages. For this '
-                         'reason you must pass auth utxo and the '
-                         'corresponding private key'))
+        usage='usage: %prog [options] [auth utxo] [cjamount] [cjaddr] ['
+        'changeaddr] [utxos..]',
+        description=('Creates an unsigned coinjoin transaction. Outputs '
+                     'a partially signed transaction hex string. The user '
+                     'must sign their inputs independently and broadcast '
+                     'them. The JoinMarket protocol requires the taker to '
+                     'have a single p2pk UTXO input to use to '
+                     'authenticate the  encrypted messages. For this '
+                     'reason you must pass auth utxo and the '
+                     'corresponding private key'))
 
     # for cjamount=0 do a sweep, and ignore change address
+    parser.add_option('-f',
+                      '--txfee',
+                      action='store',
+                      type='int',
+                      dest='txfee',
+                      default=10000,
+                      help='total miner fee in satoshis, default=10000')
     parser.add_option(
-            '-f',
-            '--txfee',
-            action='store',
-            type='int',
-            dest='txfee',
-            default=10000,
-            help='total miner fee in satoshis, default=10000')
+        '-w',
+        '--wait-time',
+        action='store',
+        type='float',
+        dest='waittime',
+        help='wait time in seconds to allow orders to arrive, default=5',
+        default=5)
+    parser.add_option('-N',
+                      '--makercount',
+                      action='store',
+                      type='int',
+                      dest='makercount',
+                      help='how many makers to coinjoin with, default=2',
+                      default=2)
     parser.add_option(
-            '-w',
-            '--wait-time',
-            action='store',
-            type='float',
-            dest='waittime',
-            help='wait time in seconds to allow orders to arrive, default=5',
-            default=5)
+        '-C',
+        '--choose-cheapest',
+        action='store_true',
+        dest='choosecheapest',
+        default=False,
+        help='override weightened offers picking and choose cheapest')
     parser.add_option(
-            '-N',
-            '--makercount',
-            action='store',
-            type='int',
-            dest='makercount',
-            help='how many makers to coinjoin with, default=2',
-            default=2)
-    parser.add_option(
-            '-C',
-            '--choose-cheapest',
-            action='store_true',
-            dest='choosecheapest',
-            default=False,
-            help='override weightened offers picking and choose cheapest')
-    parser.add_option(
-            '-P',
-            '--pick-orders',
-            action='store_true',
-            dest='pickorders',
-            default=False,
-            help=
-            'manually pick which orders to take. doesn\'t work while sweeping.')
-    parser.add_option(
-            '--yes',
-            action='store_true',
-            dest='answeryes',
-            default=False,
-            help='answer yes to everything')
+        '-P',
+        '--pick-orders',
+        action='store_true',
+        dest='pickorders',
+        default=False,
+        help=
+        'manually pick which orders to take. doesn\'t work while sweeping.')
+    parser.add_option('--yes',
+                      action='store_true',
+                      dest='answeryes',
+                      default=False,
+                      help='answer yes to everything')
     # TODO implement parser.add_option('-n', '--no-network',
     # action='store_true', dest='nonetwork', default=False, help='dont query
     # the blockchain interface, instead user must supply value of UTXOs on '
@@ -261,7 +258,8 @@ def main():
     auth_privkey = raw_input('input private key for ' + utxo_data[auth_utxo][
         'address'] + ' :')
     if utxo_data[auth_utxo]['address'] != btc.privtoaddr(
-            auth_privkey, get_p2pk_vbyte()):
+            auth_privkey,
+            magicbyte=get_p2pk_vbyte()):
         print 'ERROR: privkey does not match auth utxo'
         return
 
@@ -279,7 +277,7 @@ def main():
 
         def get_key_from_addr(self, addr):
             log.debug('getting privkey of ' + addr)
-            if btc.privtoaddr(auth_privkey, get_p2pk_vbyte()) != addr:
+            if btc.privtoaddr(auth_privkey, magicbyte=get_p2pk_vbyte()) != addr:
                 raise RuntimeError('privkey doesnt match given address')
             return auth_privkey
 

--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -549,7 +549,7 @@ class BitcoinCoreInterface(BlockchainInterface):
         # simpler to add to the same account here
         for privkey_list in wallet.imported_privkeys.values():
             for privkey in privkey_list:
-                imported_addr = btc.privtoaddr(privkey, get_p2pk_vbyte())
+                imported_addr = btc.privtoaddr(privkey, magicbyte=get_p2pk_vbyte())
                 wallet_addr_list.append(imported_addr)
         imported_addr_list = self.rpc('getaddressesbyaccount', [wallet_name])
         if not set(wallet_addr_list).issubset(set(imported_addr_list)):

--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -224,6 +224,13 @@ def load_program_config():
     global_singleton.bc_interface = get_blockchain_interface_instance(
             global_singleton.config)
 
+    #print warning if not using libsecp256k1
+    if not btc.secp_present:
+        log.debug("WARNING: You are not using the binding to libsecp256k1. The "
+                  "crypto code in use has poorer performance and security "
+                  "properties. Consider installing the binding with `pip install "
+                  "secp256k1`.")
+
 
 def get_blockchain_interface_instance(_config):
     # todo: refactor joinmarket module to get rid of loops

--- a/joinmarket/old_mnemonic.py
+++ b/joinmarket/old_mnemonic.py
@@ -265,13 +265,3 @@ def mn_decode(wlist):
         out += '%08x' % x
     return out
 
-
-if __name__ == '__main__':
-    import sys
-
-    if len(sys.argv) == 1:
-        print 'I need arguments: a hex string to encode, or a list of words to decode'
-    elif len(sys.argv) == 2:
-        print ' '.join(mn_encode(sys.argv[1]))
-    else:
-        print mn_decode(sys.argv[1:])

--- a/joinmarket/taker.py
+++ b/joinmarket/taker.py
@@ -588,8 +588,6 @@ def donation_address(cjtx):
     privkey = cjtx.wallet.get_key_from_addr(donation_utxo_data[1]['address'])
     # tx without our inputs and outputs
     tx = btc.mktx(cjtx.utxo_tx, cjtx.outputs)
-    # address = privtoaddr(privkey)
-    # signing_tx = signature_form(tx, 0, mk_pubkey_script(address), SIGHASH_ALL)
     msghash = btc.bin_txhash(tx, btc.SIGHASH_ALL)
     # generate unpredictable k
     global sign_k

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -191,7 +191,7 @@ class Wallet(AbstractWallet):
                 if epk_m['mixdepth'] not in self.imported_privkeys:
                     self.imported_privkeys[epk_m['mixdepth']] = []
                 self.addr_cache[btc.privtoaddr(
-                        privkey, get_p2pk_vbyte())] = (epk_m['mixdepth'], -1,
+                        privkey, magicbyte=get_p2pk_vbyte())] = (epk_m['mixdepth'], -1,
                     len(self.imported_privkeys[epk_m['mixdepth']]))
                 self.imported_privkeys[epk_m['mixdepth']].append(privkey)
         return decrypted_seed
@@ -217,7 +217,7 @@ class Wallet(AbstractWallet):
 
     def get_addr(self, mixing_depth, forchange, i):
         return btc.privtoaddr(
-                self.get_key(mixing_depth, forchange, i), get_p2pk_vbyte())
+                self.get_key(mixing_depth, forchange, i), magicbyte=get_p2pk_vbyte())
 
     def get_new_addr(self, mixing_depth, forchange):
         index = self.index[mixing_depth]

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -187,7 +187,15 @@ class Wallet(AbstractWallet):
                 privkey = decryptData(
                         password_key,
                         epk_m['encrypted_privkey'].decode( 'hex')).encode('hex')
-                privkey = btc.encode_privkey(privkey, 'hex_compressed')
+                #Imported keys are stored as 32 byte strings only, so the
+                #second version below is sufficient, really.
+                if not btc.secp_present:
+                    privkey = btc.encode_privkey(privkey, 'hex_compressed')
+                else:
+                    if len(privkey) != 64:
+                        raise Exception(
+                        "Unexpected privkey format; already compressed?:" + privkey)
+                    privkey += "01"
                 if epk_m['mixdepth'] not in self.imported_privkeys:
                     self.imported_privkeys[epk_m['mixdepth']] = []
                 self.addr_cache[btc.privtoaddr(

--- a/test/commontest.py
+++ b/test/commontest.py
@@ -56,7 +56,8 @@ def make_wallets(n,
                  wallet_structures=None,
                  mean_amt=1,
                  sdev_amt=0,
-                 start_index=0):
+                 start_index=0,
+                 fixed_seeds=None):
     '''n: number of wallets to be created
        wallet_structure: array of n arrays , each subarray
        specifying the number of addresses to be populated with coins
@@ -66,7 +67,10 @@ def make_wallets(n,
        Returns: a dict of dicts of form {0:{'seed':seed,'wallet':Wallet object},1:..,}'''
     if len(wallet_structures) != n:
         raise Exception("Number of wallets doesn't match wallet structures")
-    seeds = chunks(binascii.hexlify(os.urandom(15 * n)), 15 * 2)
+    if not fixed_seeds:
+        seeds = chunks(binascii.hexlify(os.urandom(15 * n)), 15 * 2)
+    else:
+        seeds = fixed_seeds
     wallets = {}
     for i in range(n):
         wallets[i + start_index] = {'seed': seeds[i],

--- a/test/test_keys.py
+++ b/test/test_keys.py
@@ -68,7 +68,7 @@ def test_wif_privkeys_valid(setup_keys):
                 from_wif_key = btc.from_wif_privkey(
                     key,
                     compressed=comp,
-                    vbyte=btc.get_version_byte(key))
+                    vbyte=btc.get_version_byte(key)-128)
                 expected_key = hex_key
                 if comp: expected_key += '01'
             assert from_wif_key == expected_key, "Incorrect key decoding: " + \

--- a/test/test_keys.py
+++ b/test/test_keys.py
@@ -21,26 +21,31 @@ def test_wif_privkeys_invalid(setup_keys):
             jm_single().config.set("BLOCKCHAIN", "network", netval)
             #if using py.test -s ; sanity check to see what's actually being tested
             print 'testing this key: ' + bad_key
-            try:
-                bad_key_format = btc.get_privkey_format(bad_key)
-                print 'has correct format: ' + bad_key_format
-            except:
-                pass
+            if "decode_privkey" in dir(btc):
+                try:
+                    bad_key_format = btc.get_privkey_format(bad_key)
+                    print 'has correct format: ' + bad_key_format
+                except:
+                    pass
             #should throw exception
             with pytest.raises(Exception) as e_info:
-                from_wif_key = btc.decode_privkey(bad_key)
+                if "decode_privkey" in dir(btc):
+                    from_wif_key = btc.decode_privkey(bad_key)
+                else:
+                    from_wif_key = btc.from_wif_compressed_privkey(
+                        bad_key, btc.get_version_byte(bad_key))
                 #in case the b58 check encoding is valid, we should
                 #also check if the leading version byte is in the
                 #expected set, and throw an error if not.
                 if chr(btc.get_version_byte(bad_key)) not in '\x80\xef':
                     raise Exception("Invalid version byte")
-                #open to discussion: the bitcoin library should throw
-                #if the compression byte is not there (discussion open 
-                #because of secp256k1, which will not accept invalid compressed
-                #raw keys)
-                if "compressed" in btc.get_privkey_format(bad_key) and \
+                #the bitcoin library should throw
+                #if the compression byte is not there (test not needed
+                #for secp256k1 branch since the wif_compressed function checks)
+                if "decode_privkey" in dir(btc):
+                    if "compressed" in btc.get_privkey_format(bad_key) and \
                    btc.b58check_to_bin(x)[-1] != '\x01':
-                    raise Exception("Invalid compression byte")
+                        raise Exception("Invalid compression byte")
 
 
 def test_wif_privkeys_valid(setup_keys):
@@ -55,8 +60,17 @@ def test_wif_privkeys_valid(setup_keys):
             print 'testing this key: ' + key
             assert chr(btc.get_version_byte(
                 key)) in '\x80\xef', "not valid network byte"
-            from_wif_key = btc.decode_privkey(key)
-            expected_key = btc.decode_privkey(hex_key)
+            if "decode_privkey" in dir(btc):
+                from_wif_key = btc.decode_privkey(key)
+                expected_key = btc.decode_privkey(hex_key)
+            else:
+                comp = prop_dict["isCompressed"]
+                from_wif_key = btc.from_wif_privkey(
+                    key,
+                    compressed=comp,
+                    vbyte=btc.get_version_byte(key))
+                expected_key = hex_key
+                if comp: expected_key += '01'
             assert from_wif_key == expected_key, "Incorrect key decoding: " + \
                    str(from_wif_key) + ", should be: " + str(expected_key)
 

--- a/test/test_mnemonic.py
+++ b/test/test_mnemonic.py
@@ -1,0 +1,55 @@
+from joinmarket import old_mnemonic
+
+import pytest
+
+@pytest.mark.parametrize(
+    "seedphrase, key, valid",
+    [
+        (["spiral", "squeeze", "strain", "sunset", "suspend", "sympathy",
+                "thigh", "throne", "total", "unseen", "weapon", "weary"],
+         '0028644c0028644f0028645200286455',
+         True),
+        (["pair", "bury", "lung", "swim", "orange", "doctor", "numb", "interest",
+          "shock", "bloom", "fragile", "screen"],
+         'fa92999d01431f961a26c876f55d3f6c',
+         True),
+        (["check", "squeeze", "strain", "sunset", "suspend", "sympathy",
+                "thigh", "throne", "total", "unseen", "weapon", "weary"],
+         '0028644c0028644f0028645200286455',
+         False),
+        (["qwerty", "check", "strain", "sunset", "suspend", "sympathy",
+                "thigh", "throne", "total", "unseen", "weapon", "weary"],
+         '',
+         False),
+        (["", "check", "strain", "sunset", "suspend", "sympathy",
+            "thigh", "throne", "total", "unseen", "weapon", "weary"],
+        '',
+        False),        
+        (["strain", "sunset"],
+         '',
+         False),                
+    ])
+def test_old_mnemonic(seedphrase, key, valid):
+    if valid:
+        assert old_mnemonic.mn_decode(seedphrase) == key
+        assert old_mnemonic.mn_encode(key) == seedphrase
+    else:
+        if len(key) > 0:
+            #test cases where the seedphrase is valid 
+            #but must not match the provided master private key
+            assert old_mnemonic.mn_decode(seedphrase) != key
+        else:
+            #test cases where the seedphrase is intrinsically invalid
+            #Already known error condition: an incorrectly short
+            #word list will NOT throw an error; this is handled by calling code
+            if len(seedphrase) < 12:
+                print "For known failure case of seedphrase less than 12: "
+                print old_mnemonic.mn_decode(seedphrase)
+            else:
+                with pytest.raises(Exception) as e_info:
+                    dummy = old_mnemonic.mn_decode(seedphrase)
+                    print "Got this return value from mn_decode: " + str(dummy)
+
+
+
+

--- a/test/test_regtest.py
+++ b/test/test_regtest.py
@@ -59,8 +59,16 @@ def test_sendpayment(setup_regtest, num_ygs, wallet_structures, mean_amt,
 
     #A significant delay is needed to wait for the yield generators to sync
     time.sleep(20)
+    if btc.secp_present:
+        destaddr = btc.privkey_to_address(
+            os.urandom(32),
+            from_hex=False,
+            magicbyte=get_p2pk_vbyte())
+    else:
+        destaddr = btc.privkey_to_address(
+            os.urandom(32),
+            magicbyte=get_p2pk_vbyte())
 
-    destaddr = btc.privkey_to_address(os.urandom(32), get_p2pk_vbyte())
     addr_valid, errormsg = validate_address(destaddr)
     assert addr_valid, "Invalid destination address: " + destaddr + \
            ", error message: " + errormsg

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -127,9 +127,9 @@ if method == 'display' or method == 'displayall' or method == 'summary':
                         balance += addrvalue['value']
                 balance_depth += balance
                 used = ('used' if k < wallet.index[m][forchange] else ' new')
-                privkey = btc.encode_privkey(
-                    wallet.get_key(m, forchange, k), 'wif_compressed',
-                    get_p2pk_vbyte()) if options.showprivkey else ''
+                privkey = btc.wif_compressed_privkey(
+                    wallet.get_key(m, forchange, k), get_p2pk_vbyte()) \
+                    if options.showprivkey else ''
                 if (method == 'displayall' or balance > 0 or
                     (used == ' new' and forchange == 0)):
                     cus_print('  m/0/%d/%d/%03d %-35s%s %.8f btc %s' %
@@ -145,9 +145,8 @@ if method == 'display' or method == 'displayall' or method == 'summary':
                         balance += addrvalue['value']
                 used = (' used' if balance > 0.0 else 'empty')
                 balance_depth += balance
-                wip_privkey = btc.encode_privkey(
-                    privkey, 'wif_compressed',
-                    get_p2pk_vbyte()) if options.showprivkey else ''
+                wip_privkey = btc.wif_compressed_privkey(
+                    privkey, get_p2pk_vbyte()) if options.showprivkey else ''
                 cus_print(' ' * 13 + '%-35s%s %.8f btc %s' % (
                     addr, used, balance / 1e8, wip_privkey))
         total_balance += balance_depth

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -127,9 +127,15 @@ if method == 'display' or method == 'displayall' or method == 'summary':
                         balance += addrvalue['value']
                 balance_depth += balance
                 used = ('used' if k < wallet.index[m][forchange] else ' new')
-                privkey = btc.wif_compressed_privkey(
-                    wallet.get_key(m, forchange, k), get_p2pk_vbyte()) \
-                    if options.showprivkey else ''
+                if options.showprivkey:
+                    if btc.secp_present:
+                        privkey = btc.wif_compressed_privkey(
+                    wallet.get_key(m, forchange, k), get_p2pk_vbyte())
+                    else:
+                        privkey = btc.encode_privkey(wallet.get_key(m,
+                                forchange, k), 'wif_compressed', get_p2pk_vbyte())
+                else:
+                    privkey = ''
                 if (method == 'displayall' or balance > 0 or
                     (used == ' new' and forchange == 0)):
                     cus_print('  m/0/%d/%d/%03d %-35s%s %.8f btc %s' %
@@ -138,15 +144,22 @@ if method == 'display' or method == 'displayall' or method == 'summary':
         if m in wallet.imported_privkeys:
             cus_print(' import addresses')
             for privkey in wallet.imported_privkeys[m]:
-                addr = btc.privtoaddr(privkey, get_p2pk_vbyte())
+                addr = btc.privtoaddr(privkey, magicbyte=get_p2pk_vbyte())
                 balance = 0.0
                 for addrvalue in wallet.unspent.values():
                     if addr == addrvalue['address']:
                         balance += addrvalue['value']
                 used = (' used' if balance > 0.0 else 'empty')
                 balance_depth += balance
-                wip_privkey = btc.wif_compressed_privkey(
-                    privkey, get_p2pk_vbyte()) if options.showprivkey else ''
+                if options.showprivkey:
+                    if btc.secp_present:
+                        wip_privkey = btc.wif_compressed_privkey(
+                    privkey, get_p2pk_vbyte())
+                    else:
+                        wip_privkey = btc.encode_privkey(privkey,
+                                            'wif_compressed', get_p2pk_vbyte())
+                else:
+                    wip_privkey = ''
                 cus_print(' ' * 13 + '%-35s%s %.8f btc %s' % (
                     addr, used, balance / 1e8, wip_privkey))
         total_balance += balance_depth
@@ -208,24 +221,29 @@ elif method == 'importprivkey':
     for privkey in privkeys:
         # TODO is there any point in only accepting wif format? check what
         # other wallets do
-        privkey_format = btc.get_privkey_format(privkey)
-        if privkey_format not in ['wif', 'wif_compressed']:
-            print('ERROR: privkey not in wallet import format')
-            print(privkey, 'skipped')
-            continue
-        if privkey_format == 'wif':
-            # TODO if they actually use an unc privkey, make sure the unc
-            # address is used
+        if not btc.secp_present:
+            privkey_format = btc.get_privkey_format(privkey)
+            if privkey_format not in ['wif', 'wif_compressed']:
+                print('ERROR: privkey not in wallet import format')
+                print(privkey, 'skipped')
+                continue
+            if privkey_format == 'wif':
+                # TODO if they actually use an unc privkey, make sure the unc
+                # address is used
 
-            # r = raw_input('WARNING: Using uncompressed private key, the vast ' +
-            #   'majority of JoinMarket transactions use compressed keys\n' +
-            #       'being so unusual is bad for privacy. Continue? (y/n):')
-            # if r != 'y':
-            #   sys.exit(0)
-            print('Uncompressed privkeys not supported (yet)')
-            print(privkey, 'skipped')
-            continue
-        privkey_bin = btc.encode_privkey(privkey, 'hex').decode('hex')
+                # r = raw_input('WARNING: Using uncompressed private key, the vast ' +
+                #   'majority of JoinMarket transactions use compressed keys\n' +
+                #       'being so unusual is bad for privacy. Continue? (y/n):')
+                # if r != 'y':
+                #   sys.exit(0)
+                print('Uncompressed privkeys not supported (yet)')
+                print(privkey, 'skipped')
+                continue
+        if btc.secp_present:
+            privkey_bin = btc.from_wif_privkey(privkey,
+                                        vbyte=get_p2pk_vbyte()).decode('hex')[:-1]
+        else:
+            privkey_bin = btc.encode_privkey(privkey, 'hex').decode('hex')
         encrypted_privkey = encryptData(wallet.password_key, privkey_bin)
         if 'imported_keys' not in wallet.walletdata:
             wallet.walletdata['imported_keys'] = []


### PR DESCRIPTION
a local version but assuming the binding is installed already with
"pip install secp256k1". Does not yet include an updated form of the
donation code for custom nonces.
add mnemonic tests
Modification so that either secp256k1 or pybtc can be used;
secp256k1 python binding is detected automatically.

NOT YET READY TO MERGE.

Passes test suite currently both with and without secp256k1 module installed on the system.

Tests ongoing. Todo: re-add alternative code for donation tx. Test tumbler and modify if needed (I expect not). Apologies for re-formatting of create-unsigned-tx; will also need some testing there.

Will also need to add warning/info message if secp256k1 is not detected.