### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Widespread use of JoinMarket could improve bitcoin's fungibility as a commodity.
 1. `sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install python libsodium-dev -y`
 2. `pip install secp256k1` (optional but recommended)
 2. `sudo apt-get install python-matplotlib -y` (optional)
-3. Download JoinMarket 0.1.3 source from [here](https://github.com/joinmarket-org/joinmarket/releases/tag/v0.1.3)
-4. Extract or unzip and `cd joinmarket-0.1.3`
+3. Download JoinMarket 0.1.4 source from [here](https://github.com/joinmarket-org/joinmarket/releases/tag/v0.1.4)
+4. Extract or unzip and `cd joinmarket-0.1.4`
 4. Generating your first wallet will populate the configuration file: `joinmarket.cfg`.
    Check if the default settings suit your needs.
 


### PR DESCRIPTION
Update installation instructions from 0.1.3 to 0.1.4.
Since 0.1.4 has been released already, I do believe this should be in master right away, so visitors who heard about the new release do not see 0.1.3 still on the first page of joinmarket