### PR TITLE
Catch exceptions in encryption initialization

### DIFF
--- a/joinmarket/__init__.py
+++ b/joinmarket/__init__.py
@@ -7,7 +7,7 @@ from .support import get_log, calc_cj_fee, debug_dump_object, \
     pick_order, cheapest_order_choose, weighted_order_choose, \
     rand_norm_array, rand_pow_array, rand_exp_array, joinmarket_alert, core_alert
 from .enc_wrapper import as_init_encryption, decode_decrypt, \
-    encrypt_encode, init_keypair, init_pubkey, get_pubkey
+    encrypt_encode, init_keypair, init_pubkey, get_pubkey, NaclError
 from .irc import IRCMessageChannel, random_nick, B_PER_SEC
 from .jsonrpc import JsonRpcError, JsonRpcConnectionError, JsonRpc
 from .maker import Maker

--- a/joinmarket/enc_wrapper.py
+++ b/joinmarket/enc_wrapper.py
@@ -14,6 +14,8 @@ import random
 
 from libnacl import public
 
+class NaclError(Exception):
+    pass
 
 def init_keypair(fname=None):
     """Create a new encryption
@@ -34,6 +36,8 @@ def get_pubkey(kp, as_hex=False):
     """Given a keypair object,
     return its public key,
     optionally in hex."""
+    if not isinstance(kp, public.SecretKey):
+        raise NaclError("Object is not a nacl keypair")
     return kp.hex_pk() if as_hex else kp.pk
 
 
@@ -42,6 +46,12 @@ def init_pubkey(hexpk, fname=None):
     hex formatted string.
     Save to file fname if specified.
     """
+    try:
+        bin_pk = binascii.unhexlify(hexpk)
+    except TypeError:
+        raise NaclError("Invalid hex")
+    if not len(bin_pk) == 32:
+        raise NaclError("Public key must be 32 bytes")
     pk = public.PublicKey(binascii.unhexlify(hexpk))
     if fname:
         pk.save(fname)
@@ -54,6 +64,10 @@ def as_init_encryption(kp, c_pk):
     pubkey c_pk, create a Box
     ready for encryption/decryption.
     """
+    if not isinstance(c_pk, public.PublicKey):
+        raise NaclError("Object is not a public key")
+    if not isinstance(kp, public.SecretKey):
+        raise NaclError("Object is not a nacl keypair")
     return public.Box(kp.sk, c_pk)
 
 

--- a/joinmarket/maker.py
+++ b/joinmarket/maker.py
@@ -9,7 +9,8 @@ import threading
 import bitcoin as btc
 from joinmarket import IRCMessageChannel
 from joinmarket.configure import get_p2pk_vbyte, load_program_config, jm_single
-from joinmarket.enc_wrapper import init_keypair, as_init_encryption, init_pubkey
+from joinmarket.enc_wrapper import init_keypair, as_init_encryption, init_pubkey, \
+     NaclError
 
 from joinmarket.support import get_log, calc_cj_fee, debug_dump_object
 from joinmarket.taker import CoinJoinerPeer
@@ -32,9 +33,15 @@ class CoinJoinOrder(object):
         self.taker_pk = taker_pk
         # create DH keypair on the fly for this Order object
         self.kp = init_keypair()
-        # the encryption channel crypto box for this Order object
-        self.crypto_box = as_init_encryption(self.kp,
+        # the encryption channel crypto box for this Order object.
+        # Invalid pubkeys must be handled by giving up gracefully (otherwise DOS)
+        try:
+            self.crypto_box = as_init_encryption(self.kp,
                                              init_pubkey(taker_pk))
+        except NaclError as e:
+            log.debug("Unable to setup crypto box with counterparty: " + repr(e))
+            self.maker.msgchan.send_error(nick, "invalid nacl pubkey: " + taker_pk)
+            return
 
         order_s = [o for o in maker.orderlist if o['oid'] == oid]
         if len(order_s) == 0:

--- a/test/test_irc_messaging.py
+++ b/test/test_irc_messaging.py
@@ -62,6 +62,10 @@ def test_junk_messages(setup_messaging):
     time.sleep(1)
     mc._IRCMessageChannel__pubmsg("junk and crap"*20)
     time.sleep(5)
+    #send a fill with an invalid pubkey to the existing yg;
+    #this should trigger a NaclError but should NOT kill it.
+    mc._IRCMessageChannel__privmsg(yg_name, "fill", "0 10000000 abcdef")
+    time.sleep(1)
     #try:
     with pytest.raises(CJPeerError) as e_info:
         mc.send_error(yg_name, "fly you fools!")


### PR DESCRIPTION
Inexplicably I did not do any sanity checking on whether the pubkey/key objects passed into the wrapper functions in enc_wrapper when I set it up.

In this PR there is a placeholder `NaclError` exception type and the pubkeys and keypair objects are checked to be of the right format.

The specific relevance is the `fill` and `pubkey` messages pass a pubkey in hex, now it is checked to be of the right format and if not, the message is ignored. See the edits to the `CoinJoinTx` and `CoinJoinOrder` objects in taker and maker.

There are some tests added also in test_enc_wrapper and in test_irc_messaging (bad `fill`), although not for the exception catch in `CoinJoinTx.start_encryption`. That test is a little tricky to write. Will see if coverage complains or not. And since the crucial point here is to catch on the maker side, I thought it better to PR as is.

