### PR TITLE
Matrix message channel basic implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "miniircd"]
 	path = miniircd
 	url = https://github.com/JoinMarket-Org/miniircd
+[submodule "matrix-python-sdk"]
+	path = matrix-python-sdk
+	url = https://github.com/matrix-org/matrix-python-sdk

--- a/joinmarket/__init__.py
+++ b/joinmarket/__init__.py
@@ -9,6 +9,7 @@ from .support import get_log, calc_cj_fee, debug_dump_object, \
 from .enc_wrapper import as_init_encryption, decode_decrypt, \
     encrypt_encode, init_keypair, init_pubkey, get_pubkey, NaclError
 from .irc import IRCMessageChannel, random_nick, B_PER_SEC
+from .matrixmc import MatrixMessageChannel
 from .jsonrpc import JsonRpcError, JsonRpcConnectionError, JsonRpc
 from .maker import Maker
 from .message_channel import MessageChannel

--- a/joinmarket/matrixmc.py
+++ b/joinmarket/matrixmc.py
@@ -1,0 +1,202 @@
+from __future__ import absolute_import, print_function
+
+import base64
+import random
+import socket
+import ssl
+import threading
+import time
+import Queue
+import sys
+import time
+import json
+
+from pprint import pformat
+from matrix_client.client import MatrixClient
+from matrix_client.api import MatrixRequestError
+from requests.exceptions import MissingSchema
+
+from getpass import getpass
+
+from joinmarket.configure import jm_single, get_network
+from joinmarket.message_channel import MessageChannel, CJPeerError, COMMAND_PREFIX
+from joinmarket.support import get_log, chunks
+from joinmarket.socks import socksocket, setdefaultproxy, PROXY_TYPE_SOCKS5
+
+matrix_config_options = ["matrix_host", "matrix_port", "matrix_chan"]
+log = get_log()
+
+#hardcoded limit is 100s of kB, we set a reasonable, sane limit
+MAX_MATRIX_LINE_LENGTH = 10000
+
+def get_rand_name():
+    import string
+    return ''.join(random.choice(string.ascii_letters) for _ in range(10))    
+
+class MatrixMessageChannel(MessageChannel):
+    def __init__(self, username=None, realname='', password=''):
+        MessageChannel.__init__(self)
+        for opt in matrix_config_options:
+            if not jm_single().config.has_option("MESSAGING", opt):
+                raise Exception(
+        "To use matrix, joinmarket.cfg must contain settings:" + ','.join(
+            [matrix_config_options]))
+        self.host = jm_single().config.get("MESSAGING", "matrix_host")
+        self.hostport= jm_single().config.getint("MESSAGING", "matrix_port")
+        self.fqhost = "https://"+self.host+":"+str(self.hostport)
+        register_needed = False
+        if realname:
+            log.debug("Realname: " + realname + " is not currently being used.")
+        if username is None:
+            username = get_rand_name()
+        self.username = "@" + username + ":" + self.host
+        if not password:
+            password = get_rand_name()
+            register_needed = True
+        self.password = password
+        self.matrix_client = MatrixClient(self.fqhost)
+        #keep track of privmsg rooms
+        self.private_rooms = {}
+        pit_room_id = jm_single().config.get("MESSAGING", "matrix_chan")
+        if get_network()=="testnet":
+            pit_room_id += "-test"
+        self.pit_room_id = "#" + pit_room_id + ":" + self.host
+        self.add_listeners()
+        self.finished = False
+        
+        #connect
+        try:
+            self.matrix_client.login_with_password(self.username, self.password)
+        except MatrixRequestError as e:
+            log.debug(e)
+            if e.code == 403:
+                log.debug(
+                "Bad username or password (this is normal for a new connection).")
+                register_needed = True
+            else:
+                log.debug("Check your sever details are correct.")
+                exit(1)
+        
+        except MissingSchema as e:
+            log.debug("Bad URL format, connection failure.")
+            log.debug(e)
+            exit(1)
+
+        if register_needed:
+            #for registration, don't provide full @name:server, just name
+            try:
+                self.matrix_client.register_with_password(username, self.password)
+            except MatrixRequestError as e:
+                log.debug("New user registration failure: " + repr(e))
+
+    def get_nicks_in_pit(self):
+        return self.pit_room.get_members()
+        #print("Got nicks in room:")
+        #print(pformat(nick_list))
+
+    def run(self):
+        #Will almost certainly need some exception handling TODO
+        self.pit_room = self.matrix_client.join_room(self.pit_room_id)
+        if self.on_welcome:
+            self.on_welcome()        
+        self.matrix_client.start_listener_thread()
+        while True:
+            if self.finished:
+                break
+            time.sleep(0.2)
+
+    def shutdown(self):
+        log.debug("Shutting down matrix connection")
+        #TODO this is not yet in API documentation, not
+        #sure it does much (was told it just expires a token)
+        #NB This is not actually correct syntax yet.
+        #self.matrix_client.api._send("POST", "/logout")
+        self.finished = True
+
+    def _announce_orders(self, orderlist, nick):
+        dest = self.pit_room_id if nick is None else nick
+        #Matrix has no meaningful line length limit but
+        #to prevent DOS make a sanity check
+        orderline = ''.join(orderlist)
+        assert len(orderline) < MAX_MATRIX_LINE_LENGTH
+        if nick is None:
+            self.pubmsg(orderline)
+        else:
+            self._privmsg(nick, '', orderline)
+
+    def add_listeners(self):
+        self.matrix_client.add_listener(self.on_message_public)
+
+    def send_privmsg_invite(self, recipient):
+        try:
+            room = self.matrix_client.create_room(is_public=False,
+                        invitees=(recipient,))
+        except:
+            log.debug("Failed to create private room for: " + recipient)
+            raise
+        self.private_rooms[recipient] = room
+
+    def _privmsg(self, recipient, cmd, msg):
+        if recipient not in self.private_rooms:
+            self.send_privmsg_invite(recipient)
+            #This is an unpleasant hack to allow the other side to join
+            #before we send our first message. TODO.
+            time.sleep(2)
+        if cmd:
+            m = COMMAND_PREFIX + cmd + ' ' + msg
+        else:
+            #allow raw send; this is for _announce_orders currently
+            m = msg
+        self.private_rooms[recipient].send_text(m)
+
+    def _pubmsg(self, msg):
+        self.pit_room.send_text(msg)
+    
+    def process_jm_privmsg_invite(self, sender, roomid):
+        #Include any logic to decide whether we want
+        #to speak to this counterparty here TODO
+        room = self.matrix_client.join_room(roomid)
+        self.private_rooms[sender] = room
+
+    # This is the main message callback
+    def on_message_public(self, event):
+        if "room_id" not in event.keys():
+            #log.debug("Received this non room event: ")
+            #log.debug(event['type'])
+            return
+        if event['type'] != "m.room.member" and \
+           event['room_id'] not in [self.pit_room.room_id] + \
+           [x.room_id for x in self.private_rooms.values()]:
+            log.debug("Received an event for a room we're not connected to: ",
+                  event['room_id'], ", ignoring.")
+            log.debug("We currently have these rooms: ")
+            log.debug(pformat([self.pit_room.room_id] + \
+                          [x.room_id for x in self.private_rooms.values()]))
+            return
+        if event['type'] == "m.room.member":
+            sender = event['sender']
+            #for now just printing any joins
+            if event['membership'] == "invite":
+                if not event['state_key'] == self.username:
+                    #these are received when we send invites, ignore
+                    return
+                rm_id = event['room_id']
+                self.process_jm_privmsg_invite(sender, rm_id)
+        elif event['type'] == "m.room.message":
+            sender = event['sender']
+            if sender==self.username:
+                return
+            if event['content']['msgtype'] == "m.text":
+                #Here we proceed with the joinmarket messaging protocol
+                if event['room_id'] in [x.room_id for x in self.private_rooms.values()]:
+                    log.debug("Received a private message from " + sender)
+                    self.on_privmsg(sender, event['content']['body'])
+                else:
+                    #if event['room_id'] != self.pit_room.room_id:
+                    #    log.debug("Received a privmsg for a not-yet created room.")
+                    #    self.on_privmsg(sender, event['content']['body'])
+                    #else:
+                    self.on_pubmsg(sender, event['content']['body'])
+        #else:
+        #    log.debug("What is this? " + event['type'])
+

--- a/joinmarket/matrixmc.py
+++ b/joinmarket/matrixmc.py
@@ -48,8 +48,10 @@ class MatrixMessageChannel(MessageChannel):
         if realname:
             log.debug("Realname: " + realname + " is not currently being used.")
         if username is None:
-            username = get_rand_name()
-        self.username = "@" + username + ":" + self.host
+            self.base_username = get_rand_name()
+        else:
+            self.base_username = username
+        self.username = "@" + self.base_username + ":" + self.host
         if not password:
             password = get_rand_name()
             register_needed = True
@@ -63,50 +65,66 @@ class MatrixMessageChannel(MessageChannel):
         self.pit_room_id = "#" + pit_room_id + ":" + self.host
         self.add_listeners()
         self.finished = False
-        
+        self.logged_in = False
+        self.nb = None
+
+    def debug(self, msg):
+        log.debug(" *" + self.base_username + "* " + msg)
+
+    def get_nicks_in_pit(self):
+        return self.pit_room.get_members()
+
+    def join_room(self, room):
+        rm = self.matrix_client.join_room(room_id_or_alias=room)
+        frompoint = self.matrix_client.end
+        response = self.matrix_client.api._send("GET",
+                            "/rooms/"+rm.room_id+'/messages',
+                            query_params={"from":frompoint,"dir":"b",
+                                                            "limit":1})
+        #don't reset the endpoint upwards
+        #self.matrix_client.end = response["end"]
+        return (rm, response)
+
+    def run(self):
         #connect
         try:
             self.matrix_client.login_with_password(self.username, self.password)
         except MatrixRequestError as e:
             log.debug(e)
             if e.code == 403:
-                log.debug(
+                self.debug(
                 "Bad username or password (this is normal for a new connection).")
                 register_needed = True
             else:
-                log.debug("Check your sever details are correct.")
+                self.debug("Check your sever details are correct.")
                 exit(1)
         
         except MissingSchema as e:
-            log.debug("Bad URL format, connection failure.")
+            self.debug("Bad URL format, connection failure.")
             log.debug(e)
             exit(1)
 
         if register_needed:
             #for registration, don't provide full @name:server, just name
             try:
-                self.matrix_client.register_with_password(username, self.password)
+                self.matrix_client.register_with_password(self.base_username,
+                                                          self.password)
             except MatrixRequestError as e:
-                log.debug("New user registration failure: " + repr(e))
+                self.debug("New user registration failure: " + repr(e))
 
-    def get_nicks_in_pit(self):
-        return self.pit_room.get_members()
-        #print("Got nicks in room:")
-        #print(pformat(nick_list))
-
-    def run(self):
         #Will almost certainly need some exception handling TODO
-        self.pit_room = self.matrix_client.join_room(self.pit_room_id)
+        self.pit_room, resp = self.join_room(self.pit_room_id)
         if self.on_welcome:
-            self.on_welcome()        
+            self.on_welcome()
         self.matrix_client.start_listener_thread()
+        self.logged_in = True
         while True:
             if self.finished:
                 break
             time.sleep(0.2)
 
     def shutdown(self):
-        log.debug("Shutting down matrix connection")
+        self.debug("Shutting down matrix connection")
         #TODO this is not yet in API documentation, not
         #sure it does much (was told it just expires a token)
         #NB This is not actually correct syntax yet.
@@ -129,11 +147,14 @@ class MatrixMessageChannel(MessageChannel):
 
     def send_privmsg_invite(self, recipient):
         try:
+            start_time = time.time()
             room = self.matrix_client.create_room(is_public=False,
                         invitees=(recipient,))
+            duration = time.time() - start_time
         except:
-            log.debug("Failed to create private room for: " + recipient)
+            self.debug("Failed to create private room for: " + recipient)
             raise
+        self.debug("Create room took: " + str(duration))
         self.private_rooms[recipient] = room
 
     def _privmsg(self, recipient, cmd, msg):
@@ -155,22 +176,29 @@ class MatrixMessageChannel(MessageChannel):
     def process_jm_privmsg_invite(self, sender, roomid):
         #Include any logic to decide whether we want
         #to speak to this counterparty here TODO
+        #artificial delay so we don't get the message in time
+        start_time = time.time()
         room = self.matrix_client.join_room(roomid)
+        duration = time.time() -start_time
+        self.debug("Room join took: " + str(duration))
         self.private_rooms[sender] = room
 
     # This is the main message callback
     def on_message_public(self, event):
+        if event['type']=="m.presence":
+            return
         if "room_id" not in event.keys():
-            #log.debug("Received this non room event: ")
-            #log.debug(event['type'])
+            self.debug(pformat(event))
+            #self.debug("Received this non room event: ")
+            #self.debug(event['type'])
             return
         if event['type'] != "m.room.member" and \
            event['room_id'] not in [self.pit_room.room_id] + \
            [x.room_id for x in self.private_rooms.values()]:
-            log.debug("Received an event for a room we're not connected to: ",
+            self.debug("Received an event for a room we're not connected to: ",
                   event['room_id'], ", ignoring.")
-            log.debug("We currently have these rooms: ")
-            log.debug(pformat([self.pit_room.room_id] + \
+            self.debug("We currently have these rooms: ")
+            self.debug(pformat([self.pit_room.room_id] + \
                           [x.room_id for x in self.private_rooms.values()]))
             return
         if event['type'] == "m.room.member":
@@ -183,20 +211,21 @@ class MatrixMessageChannel(MessageChannel):
                 rm_id = event['room_id']
                 self.process_jm_privmsg_invite(sender, rm_id)
         elif event['type'] == "m.room.message":
+            #self.debug("RECEIVED")
+            #self.debug(pformat(event))
             sender = event['sender']
             if sender==self.username:
                 return
             if event['content']['msgtype'] == "m.text":
                 #Here we proceed with the joinmarket messaging protocol
                 if event['room_id'] in [x.room_id for x in self.private_rooms.values()]:
-                    log.debug("Received a private message from " + sender)
+                    self.debug("Received a private message from " + sender)
                     self.on_privmsg(sender, event['content']['body'])
                 else:
                     #if event['room_id'] != self.pit_room.room_id:
-                    #    log.debug("Received a privmsg for a not-yet created room.")
+                    #    self.debug("Received a privmsg for a not-yet created room.")
                     #    self.on_privmsg(sender, event['content']['body'])
                     #else:
                     self.on_pubmsg(sender, event['content']['body'])
-        #else:
-        #    log.debug("What is this? " + event['type'])
-
+        else:
+            self.debug("What is this? " + event['type'])

--- a/joinmarket/message_channel.py
+++ b/joinmarket/message_channel.py
@@ -138,6 +138,7 @@ class MessageChannel(object):
         for order in orderlist:
             orderlines.append(COMMAND_PREFIX + order['ordertype'] + \
                     ' ' + ' '.join([str(order[k]) for k in order_keys]))
+        log.debug("Announcing orders to: " + str(nick))
         self._announce_orders(orderlines, nick)
 
     def check_for_orders(self, nick, _chunks):

--- a/sendpayment.py
+++ b/sendpayment.py
@@ -10,7 +10,8 @@ from optparse import OptionParser
 # sys.path.insert(0, os.path.join(data_dir, 'joinmarket'))
 import time
 
-from joinmarket import Taker, load_program_config, IRCMessageChannel
+from joinmarket import Taker, load_program_config, IRCMessageChannel, \
+     MatrixMessageChannel
 from joinmarket import validate_address, jm_single
 from joinmarket import random_nick
 from joinmarket import get_log, choose_sweep_orders, choose_orders, \
@@ -304,14 +305,18 @@ def main():
     else:
         wallet = BitcoinCoreWallet(fromaccount=wallet_name)
     jm_single().bc_interface.sync_wallet(wallet)
-
-    irc = IRCMessageChannel(jm_single().nickname)
-    taker = SendPayment(irc, wallet, destaddr, amount, options.makercount,
+    #TODO smarter config handling (e.g. what if both?)
+    if jm_single().config.has_option("MESSAGING", "matrix_host"):
+        mcClass = MatrixMessageChannel
+    else:
+        mcClass = IRCMessageChannel
+    mchannel = mcClass(jm_single().nickname)
+    taker = SendPayment(mchannel, wallet, destaddr, amount, options.makercount,
                         options.txfee, options.waittime, options.mixdepth,
                         options.answeryes, chooseOrdersFunc)
     try:
-        log.debug('starting irc')
-        irc.run()
+        log.debug('starting message channel')
+        mchannel.run()
     except:
         log.debug('CRASHING, DUMPING EVERYTHING')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'wallet_name', 'seed'])

--- a/test/regtest_joinmarket.cfg
+++ b/test/regtest_joinmarket.cfg
@@ -17,6 +17,9 @@ usessl = false
 socks5 = false
 socks5_host = localhost
 socks5_port = 9150
+matrix_host = joinmarket.me
+matrix_port = 8448
+matrix_chan = joinmarket-pit
 [POLICY]
 # for dust sweeping, try merge_algorithm = gradual
 # for more rapid dust sweeping, try merge_algorithm = greedy

--- a/test/test_matrix_messaging.py
+++ b/test/test_matrix_messaging.py
@@ -1,0 +1,134 @@
+#! /usr/bin/env python
+from __future__ import absolute_import
+'''Tests of joinmarket bots messaging (using matrix) '''
+
+import subprocess
+import signal
+import os
+import pytest
+import time
+import threading
+from commontest import local_command, make_wallets
+from joinmarket.message_channel import CJPeerError
+from joinmarket.irc import random_nick
+from joinmarket import load_program_config, MatrixMessageChannel
+
+python_cmd = "python2"
+yg_cmd = "yield-generator-basic.py"
+yg_name = None
+
+class DummyMC(MatrixMessageChannel):
+    def __init__(self, username=None):
+        super(DummyMC, self).__init__(username)
+
+def on_order_seen(counterparty, oid, ordertype, minsize,
+                                           maxsize, txfee, cjfee):
+    global yg_name
+    print "received order from: " + counterparty
+    yg_name = counterparty
+
+def on_pubkey(pubkey):
+    print "received pubkey: " + pubkey
+
+class RawMatrixThread(threading.Thread):
+
+    def __init__(self, matrixmsgchan):
+        #NB Don't name threads if they're not unique!!
+        threading.Thread.__init__(self)
+        self.daemon = True
+        self.matrixmsgchan = matrixmsgchan
+    
+    def run(self):
+        self.matrixmsgchan.run()
+
+#The two tests below are in a very primitive
+#state; a lot more investigation is needed.
+
+def test_privmsg(setup_messaging):
+    
+    mc = DummyMC(random_nick())
+    def oof(nick, oid, amount, taker_pubkey):
+        print "got a fill from: " + nick
+        print "this oid: " + str(oid)
+        #mc.privmsg(nick, "auth", "blah blah")
+    mc.register_maker_callbacks(on_order_fill=oof)
+    RawMatrixThread(mc).start()
+    while not mc.logged_in:
+        time.sleep(0.1)
+        
+    mc2 = DummyMC(random_nick())
+    def oos(counterparty, oid, ordertype, minsize,
+                                               maxsize, txfee, cjfee):
+        print "got a order from cty: " + counterparty
+        mc2.privmsg(counterparty, "fill", ' '.join([str(oid), str(23456), "deadbeef"]))
+    mc2.register_orderbookwatch_callbacks(on_order_seen=oos)
+    RawMatrixThread(mc2).start()
+    while not mc2.logged_in:
+        time.sleep(0.1)
+    
+    orders = []
+    for oid in range(10):
+        order = {'oid': oid + 1,
+                         'ordertype': 'relorder',
+                         'minsize': 22,
+                         'maxsize': 500,
+                         'txfee': 2000,
+                         'cjfee': 7,
+                         'mixdepth': oid}
+        orders.append(order)
+    mc.announce_orders(orders)
+    time.sleep(10)
+    mc.shutdown()
+    mc2.shutdown()
+
+def test_junk_messages(setup_messaging):
+    #start a yg bot just to receive messages
+    wallets = make_wallets(1,
+                           wallet_structures=[[1,0,0,0,0]],
+                           mean_amt=1)
+    wallet = wallets[0]['wallet']
+    ygp = local_command([python_cmd, yg_cmd,\
+                             str(wallets[0]['seed'])], bg=True)
+    
+    time.sleep(20)
+    #start a raw IRCMessageChannel instance in a thread;
+    #then call send_* on it with various errant messages
+    mc = DummyMC()
+    mc.register_orderbookwatch_callbacks(on_order_seen=on_order_seen)
+    mc.register_taker_callbacks(on_pubkey=on_pubkey)    
+    RawMatrixThread(mc).start()
+    while not mc.logged_in:
+        time.sleep(0.1)
+    mc.request_orderbook()
+    time.sleep(1)
+    #now try directly
+    mc.pubmsg("!orderbook")
+    time.sleep(1)
+    #should be ignored; can we check?
+    mc.pubmsg("!orderbook!orderbook")
+    time.sleep(1)
+    #assuming MAX_MATRIX_LINE_LENGTH is not something crazy
+    #small like a few hundred, this should succeed
+    mc.pubmsg("junk and crap"*45)
+    time.sleep(2)
+    #try a long order announcement in public
+    #because we don't want to build a real orderbook,
+    #call the underlying IRC announce function.
+    #TODO: how to test that the sent format was correct?
+    mc._announce_orders(["!abc def gh 0001"]*30, None)
+    time.sleep(5)
+    #try:
+    with pytest.raises(CJPeerError) as e_info:
+        mc.send_error(yg_name, "fly you fools!")
+    time.sleep(5)
+    mc.shutdown()
+    ygp.send_signal(signal.SIGINT)
+    ygp.wait()
+
+@pytest.fixture(scope="module")
+def setup_messaging():  
+    load_program_config()
+
+
+
+

--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -6,7 +6,7 @@ import os
 import time
 from optparse import OptionParser
 
-from joinmarket import Maker, IRCMessageChannel
+from joinmarket import Maker, IRCMessageChannel, MatrixMessageChannel
 from joinmarket import BlockrInterface
 from joinmarket import jm_single, get_network, load_program_config
 from joinmarket import random_nick
@@ -227,19 +227,24 @@ def main():
     # nickname
 
     log.debug('starting yield generator')
-    irc = IRCMessageChannel(jm_single().nickname,
+    #TODO smarter config handling (e.g. what if both?)
+    if jm_single().config.has_option("MESSAGING", "matrix_host"):
+        mcClass = MatrixMessageChannel
+    else:
+        mcClass = IRCMessageChannel
+    mchannel = mcClass(jm_single().nickname,
                             realname='btcint=' + jm_single().config.get(
                                 "BLOCKCHAIN", "blockchain_source"),
                             password=nickserv_password)
-    maker = YieldGenerator(irc, wallet)
+    maker = YieldGenerator(mchannel, wallet)
     try:
-        log.debug('connecting to irc')
-        irc.run()
+        log.debug('connecting to message channel')
+        mchannel.run()
     except:
         log.debug('CRASHING, DUMPING EVERYTHING')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
         debug_dump_object(maker)
-        debug_dump_object(irc)
+        debug_dump_object(mchannel)
         import traceback
         log.debug(traceback.format_exc())
 


### PR DESCRIPTION
This PR is currently for TESTING, not yet merge-able.

If you want to test this PR with me, do something like:

    git fetch origin refs/pull/541/head:pull_541

where `origin` should be replaced with whatever your name is for this repo (origin is the default). A branch is automatically created with name pull_541 in your local repo. Make sure to also `git checkout pull_541` so as to run this code.

You also need to `pip install matrix-client`.

Logic: If the user sets the variables:

```
matrix_host = joinmarket.me
matrix_port = 8448
matrix_chan = joinmarket-pit
```

in the [MESSAGING] section of the config, then the code will connect over the matrix homeserver at joinmarket.me:8448, room joinmarket-pit. If `matrix_host` is not found, you default back to IRC settings.

If anyone with a testnet wallet could do this (ping me), we could carry out some tests live. I have already tested with regtest of course (the test suite). It is somewhat slower due to setup time, but actual transactions process faster due to no throttling.

The main TODO is to duplex this, allowing to read and write orders and updates to both IRC and matrix.

The secondary TODO is more fuzzy but maybe important: in order to do privmsgs a temporary private room has to be setup, with the default code from the sdk this involves some delay (currently hardcoded at 2 seconds, yuck - timing tests seem to indicate that room creation has a delay of ~1s); would like to make this quicker/cleaner. Some investigation around the end of April ended up with me being somewhat dispirited about how complex the API is; in particular, it seems to be built with a lot of statefulness in mind; by default the client is downloading everything and anything. Anyway, this needs a lot of work to improve.