### PR TITLE
Change sanity_check in yield-generator-oscillator.py to accept long integers for maxoffer and minoffer.

### DIFF
--- a/yield-generator-oscillator.py
+++ b/yield-generator-oscillator.py
@@ -180,8 +180,8 @@ def sanity_check(offers):
         assert offer['txfee'] >= 0
         if offer_high:
             assert offer['maxsize'] <= offer_high
-        assert isinstance(offer['minsize'], int)
-        assert isinstance(offer['maxsize'], int)
+        assert (isinstance(offer['minsize'], int) or isinstance(offer['minsize'], long))
+        assert (isinstance(offer['maxsize'], int) or isinstance(offer['maxsize'], long))
         assert isinstance(offer['txfee'], int)
         assert offer['minsize'] >= offer_low
         if offer['ordertype'] == 'absorder':


### PR DESCRIPTION
Python 2.7 does not necessarily support 64 bit integers for type int. It's not uncommon that Python 2.7 for Windows will only allow 32 bit signed integers for type int, and that larger integers will be supported as type long.  As a result values as low as pow(2,31) = 214783648 santoshis = 21.47483648 bitcoin will be stored as a long in that case, even if one attempts to cast them as int. Changing the sanity test to allow type long seems to be the minimum change to fix this problem without creating conflicts for other users.