### PR TITLE
Allow 'maxsize' and 'minsize' to be type long as well as type int.

### DIFF
--- a/yield-generator-oscillator.py
+++ b/yield-generator-oscillator.py
@@ -181,8 +181,8 @@ def sanity_check(offers):
         assert offer['txfee'] >= 0
         if offer_high:
             assert offer['maxsize'] <= offer_high
-        assert isinstance(offer['minsize'], int)
-        assert isinstance(offer['maxsize'], int)
+        assert (isinstance(offer['minsize'], int) or isinstance(offer['minsize'], long))
+        assert (isinstance(offer['maxsize'], int) or isinstance(offer['maxsize'], long))
         assert isinstance(offer['txfee'], int)
         assert offer['minsize'] >= offer_low
         if offer['ordertype'] == 'absorder':


### PR DESCRIPTION
This change is necessary for compatibility with 32 bit int.  The minimum specification for Python 2.7 int type is 32 bit, and apparently this is not uncommon in Python 2.7 for Windows even when using 64 bit processors. This is only a change to the sanity_check function.