### PR TITLE
fix crash on insufficient coins in any mixdepth

### DIFF
--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -104,6 +104,8 @@ class YieldGenerator(Maker):
         filtered_mix_balance = [m
                                 for m in mix_balance.iteritems()
                                 if m[1] >= total_amount]
+        if not filtered_mix_balance:
+            return None, None, None
         log.debug('mix depths that have enough = ' + str(filtered_mix_balance))
         filtered_mix_balance = sorted(filtered_mix_balance, key=lambda x: x[0])
         mixdepth = filtered_mix_balance[0][0]

--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -159,6 +159,8 @@ class YieldGenerator(Maker):
         filtered_mix_balance = [m
                                 for m in mix_balance.iteritems()
                                 if m[1] >= total_amount]
+        if not filtered_mix_balance:
+            return None, None, None
         log.debug('mix depths that have enough, filtered_mix_balance = ' + str(
             filtered_mix_balance))
 


### PR DESCRIPTION
In oid_to_order in the yield generator (mixdepth, basic), if there aren't sufficient coins in any mixdepth, `filtered_mix_balance` is set to [], which causes a crash on the call to `filtered_mix_balance[0][0]`
