### PR TITLE
sendpayment/tumbler: increase default maker count

### DIFF
--- a/sendpayment.py
+++ b/sendpayment.py
@@ -225,15 +225,15 @@ def main():
                       action='store',
                       type='int',
                       dest='makercount',
-                      help='how many makers to coinjoin with, default random from 2 to 4',
-                      default=random.randint(2, 4))
+                      help='how many makers to coinjoin with, default random from 4 to 6',
+                      default=random.randint(4, 6))
     parser.add_option(
         '-C',
         '--choose-cheapest',
         action='store_true',
         dest='choosecheapest',
         default=False,
-        help='override weightened offers picking and choose cheapest')
+        help='override weightened offers picking and choose cheapest. this might reduce anonymity.')
     parser.add_option(
         '-P',
         '--pick-orders',

--- a/tumbler.py
+++ b/tumbler.py
@@ -451,16 +451,16 @@ def main():
             action='store',
             dest='makercountrange',
             help=
-            'Input the mean and spread of number of makers to use. e.g. 3 1.5 will be a normal distribution '
-            'with mean 3 and standard deveation 1.5 inclusive, default=3 1.5',
-            default=(3, 1.5))
+            'Input the mean and spread of number of makers to use. e.g. 5 1.5 will be a normal distribution '
+            'with mean 5 and standard deveation 1.5 inclusive, default=5 1.5',
+            default=(5, 1.5))
     parser.add_option(
             '--minmakercount',
             type='int',
             dest='minmakercount',
-            default=2,
+            default=3,
             help=
-            'The minimum maker count in a transaction, random values below this are clamped at this number. default=2')
+            'The minimum maker count in a transaction, random values below this are clamped at this number. default=3')
     parser.add_option(
             '-M',
             '--mixdepthcount',


### PR DESCRIPTION
I propose a change of the default maker count from 2-4 to 4-6 (sendpayment) and from median 3 with stdev 1.5 to median 5 with stdev 1.5 (tumbler).

Reasoning:
The first research about JoinMarket ([Join Me on a Market for Anonymity](http://weis2016.econinfosec.org/wp-content/uploads/sites/2/2016/05/WEIS_2016_paper_58.pdf)) has shown that it is possible to increase the costs of a sybil attacker significantly by increasing the maker count, see Table 1 and Table 2 in the paper.

This could already be achieved by takers if they specify their preferred maker count in the command line parameters. Users use joinmarket as taker in search for anonymity for their coins. As many user do not change default values, the default should be set to a more secure value (see Figure 5 in that paper, that the majority does not change the default; mind that this is data from when the default was still N=2). Defaults are important.

If takers do not like the value, they can always adjust it downwards as they please.