### PR TITLE
sendpayment: increase default waittime from 5 to 15

### DIFF
--- a/sendpayment.py
+++ b/sendpayment.py
@@ -218,8 +218,8 @@ def main():
         action='store',
         type='float',
         dest='waittime',
-        help='wait time in seconds to allow orders to arrive, default=5',
-        default=5)
+        help='wait time in seconds to allow orders to arrive, default=15',
+        default=15)
     parser.add_option('-N',
                       '--makercount',
                       action='store',


### PR DESCRIPTION
The default time to wait for offers to arrive of 5 seconds is too low in some instances.

If I initiate a sendpayment and evaluate the time until the last offers arrive by private message, it sometimes is within 7-10 seconds.
Arguably users connected via TOR sometimes have higher latencies (esp. when both taker and maker are connected via TOR).

Increasing the default therefor might be beneficiary to takers with very little downside:
- pro: possibly more anonymity (late answers will probably be more private users connecting via TOR)
- pro: possibly cheaper joins (late answer could have lower fees)
- con: user has to wait a few more seconds

tumbler.py already has a longer default waiting time and does not need this change.