### PR TITLE
socks.py: randomize socks5 credentials for tor stream isolation

### DIFF
--- a/joinmarket/socks.py
+++ b/joinmarket/socks.py
@@ -32,6 +32,7 @@ for tunneling connections through SOCKS proxies.
 
 import socket
 import struct
+import random
 
 PROXY_TYPE_SOCKS4 = 1
 PROXY_TYPE_SOCKS5 = 2
@@ -113,8 +114,8 @@ def setdefaultproxy(proxytype=None,
                     addr=None,
                     port=None,
                     rdns=True,
-                    username=None,
-                    password=None):
+                    username=str(random.randrange(10000000, 99999999)),
+                    password=str(random.randrange(10000000, 99999999))):
     """setdefaultproxy(proxytype, addr[, port[, rdns[, username[, password]]]])
 	Sets a default proxy which all further socksocket objects will use,
 	unless explicitly changed.
@@ -207,7 +208,7 @@ class socksocket(socket.socket):
             # Okay, we need to perform a basic username/password
             # authentication.
             self.sendall("\x01" + chr(len(self.__proxy[4])) + self.__proxy[4] +
-                         chr(len(self.proxy[5])) + self.__proxy[5])
+                         chr(len(self.__proxy[5])) + self.__proxy[5])
             authstat = self.__recvall(2)
             if authstat[0] != "\x01":
                 # Bad response


### PR DESCRIPTION
As suggested in #543 this PR allows TOR stream isolation by using random username/passwords.

Streams are only isolated when connecting to the clearnet IP address of the irc server though (tested: works).

If the hidden irc service is used, streams are NOT isolated. This is not supported by TOR according to fluffypony from the JM irc channel. Basically: connections to **different** hidden services are isolated by default. Connections to the **same** hidden service **cannot** be isolated.

This will therefor also work nicely for things like connecting to random bitcoin nodes to push transactions anonymously as belcher suggested in #503 .

I think therefor, that there is no downside to this fix.