### PR TITLE
yieldgens: fix issue 567 for max_size orders

### DIFF
--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -85,7 +85,7 @@ class YieldGenerator(Maker):
         order = {'oid': 0,
                  'ordertype': ordertype,
                  'minsize': minsize,
-                 'maxsize': mix_balance[max_mix] - jm_single().DUST_THRESHOLD,
+                 'maxsize': mix_balance[max_mix] - max(jm_single().DUST_THRESHOLD,txfee),
                  'txfee': txfee,
                  'cjfee': f}
 

--- a/yield-generator-deluxe.py
+++ b/yield-generator-deluxe.py
@@ -196,11 +196,16 @@ class YieldGenerator(Maker):
             return override_offers
 
         offer_lowx = max(offer_low, min_output_size)
+
+	if txfee_spread == 'custom':
+	    maximum_conf_txfees = max(custom_txfees)
+	else:
+	    maximum_conf_txfees = txfee_high
         if offer_high:
             offer_highx = min(offer_high,
-                              largest_mixdepth_size - min_output_size)
+                              largest_mixdepth_size - max(min_output_size,maximum_conf_txfees))
         else:
-            offer_highx = largest_mixdepth_size - min_output_size
+            offer_highx = largest_mixdepth_size - max(min_output_size,maximum_conf_txfees)
             # note, subtracting mix_output_size here to make minimum size change
             # todo, make an offer for exactly the max size with no change
 

--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -121,7 +121,7 @@ class YieldGenerator(Maker):
                      'ordertype': 'relorder',
                      'minsize': max(mins - jm_single().DUST_THRESHOLD,
                                     jm_single().DUST_THRESHOLD) + 1,
-                     'maxsize': max(balance - jm_single().DUST_THRESHOLD,
+                     'maxsize': max(balance - max(jm_single().DUST_THRESHOLD, txfee),
                                     jm_single().DUST_THRESHOLD),
                      'txfee': txfee,
                      'cjfee': thecjfee[oid + delta],


### PR DESCRIPTION
Fixes issue #567 

Problematic were these lines: https://github.com/JoinMarket-Org/joinmarket/blob/master/yield-generator-mixdepth.py#L157-161

If a txfee > the dust_threshold was set and maximum size order was requested, no mixdepth could contain enough coins to cover amount+txfee. This mostly wasnt an issue until now because most makers have a txfee=0 or did not even notice, because this does not crash the yieldgen-bot.

So this PR sets the announced maximum order to:
max_coins_in_one_mixdepth - max(dust_threshold, txfee)