### PR TITLE
modify wallet sync to account for requested but unused addresses, add…

### DIFF
--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -161,9 +161,9 @@ class BlockrInterface(BlockchainInterface):
                 if last_used_addr == '':
                     wallet.index[mix_depth][forchange] = 0
                 else:
-                    wallet.index[mix_depth][forchange] = wallet.addr_cache[
-                                                             last_used_addr][
-                                                             2] + 1
+		    next_avail_idx = max([wallet.addr_cache[last_used_addr][2]+1,
+		                        wallet.index_cache[mix_depth][forchange]])
+		    wallet.index[mix_depth][forchange] = next_avail_idx
 
     def sync_unspent(self, wallet):
         # finds utxos in the wallet

--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -637,8 +637,9 @@ class BitcoinCoreInterface(BlockchainInterface):
                 if last_used_addr == '':
                     wallet.index[mix_depth][forchange] = 0
                 else:
-                    wallet.index[mix_depth][forchange] = \
-                        wallet.addr_cache[last_used_addr][2] + 1
+		    next_avail_idx = max([wallet.addr_cache[last_used_addr][2]+1,
+		                        wallet.index_cache[mix_depth][forchange]])
+		    wallet.index[mix_depth][forchange] = next_avail_idx
 
         wallet_addr_list = []
         if len(too_few_addr_mix_change) > 0:

--- a/test/test_wallets.py
+++ b/test/test_wallets.py
@@ -10,7 +10,7 @@ import pexpect
 import random
 import subprocess
 import unittest
-from commontest import local_command, interact, make_wallets
+from commontest import local_command, interact, make_wallets, make_sign_and_push
 
 import bitcoin as btc
 import pytest
@@ -18,8 +18,118 @@ from joinmarket import load_program_config, jm_single
 from joinmarket import get_p2pk_vbyte, get_log, Wallet
 from joinmarket.support import chunks, select_gradual, \
      select_greedy, select_greediest
+from joinmarket.wallet import estimate_tx_fee
 
 log = get_log()
+
+def do_tx(wallet, amount):
+    ins_full = wallet.select_utxos(0, amount)
+    cj_addr = wallet.get_internal_addr(1)
+    change_addr = wallet.get_internal_addr(0)
+    wallet.update_cache_index()
+    txid = make_sign_and_push(ins_full, wallet, amount,
+                              output_addr=cj_addr,
+                              change_addr=change_addr,
+                              estimate_fee=True)
+    assert txid
+    time.sleep(2) #blocks
+    jm_single().bc_interface.sync_unspent(wallet)
+
+@pytest.mark.parametrize(
+    "num_txs, fake_count, wallet_structure, amount, wallet_file, password",
+    [
+        (3, 13, [11,3,4,5,6], 150000000, 'test_import_wallet.json', 'import-pwd'
+         ),
+        #Uncomment all these for thorough tests. Passing currently.
+        #Lots of used addresses
+        #(7, 1, [51,3,4,5,6], 150000000, 'test_import_wallet.json', 'import-pwd'
+        #),
+        #(3, 1, [3,1,4,5,6], 50000000, 'test_import_wallet.json', 'import-pwd'
+        #),
+        #No spams/fakes
+        #(2, 0, [5,20,1,1,1], 50000000, 'test_import_wallet.json', 'import-pwd'
+        # ),
+        #Lots of transactions and fakes
+        #(25, 30, [30,20,1,1,1], 50000000, 'test_import_wallet.json', 'import-pwd'
+        # ),
+    ])
+def test_wallet_sync(setup_wallets, num_txs, fake_count,
+                     wallet_structure, amount, wallet_file, password):
+    setup_import(mainnet=False)
+    wallet = make_wallets(1,[wallet_structure],
+                          fixed_seeds=[wallet_file],
+                          test_wallet=True, passwords=[password])[0]['wallet']
+    sync_count = 0
+    jm_single().bc_interface.wallet_synced = False
+    while not jm_single().bc_interface.wallet_synced:
+        jm_single().bc_interface.sync_wallet(wallet)
+        sync_count += 1
+        #avoid infinite loop
+        assert sync_count < 10
+        log.debug("Tried " + str(sync_count) + " times")
+
+    assert jm_single().bc_interface.wallet_synced
+    #do some transactions with the wallet, then close, then resync
+    for i in range(num_txs):
+        do_tx(wallet, amount)
+        log.debug("After doing a tx, index is now: " + str(wallet.index))
+        #simulate a spammer requesting a bunch of transactions. This
+        #mimics what happens in CoinJoinOrder.__init__()
+        for j in range(fake_count):
+            #Note that as in a real script run,
+            #the initial call to sync_wallet will
+            #have set wallet_synced to True, so these will
+            #trigger actual imports.
+            cj_addr = wallet.get_internal_addr(0)
+            change_addr = wallet.get_internal_addr(0)
+            wallet.update_cache_index()
+            log.debug("After doing a spam, index is now: " + str(wallet.index))
+
+    assert wallet.index[0][1] == num_txs+fake_count*2*num_txs
+
+    #Attempt re-sync, simulating a script restart.
+
+    jm_single().bc_interface.wallet_synced = False
+    sync_count = 0
+    #Probably should be fixed in main code:
+    #wallet.index_cache is only assigned in Wallet.__init__(),
+    #meaning a second sync in the same script, after some transactions,
+    #will not know about the latest index_cache value (see is_index_ahead_of_cache),
+    #whereas a real re-sync will involve reading the cache from disk.
+    #Hence, simulation of the fact that the cache index will
+    #be read from the file on restart:
+    wallet.index_cache = wallet.index
+
+    while not jm_single().bc_interface.wallet_synced:
+        #Wallet.__init__() resets index to zero.
+        wallet.index = []
+        for i in range(5):
+            wallet.index.append([0, 0])
+        #Wallet.__init__() also updates the cache index
+        #from file, but we can reuse from the above pre-loop setting,
+        #since nothing else in sync will overwrite the cache.
+
+        #for regtest add_watchonly_addresses does not exit(), so can
+        #just repeat as many times as possible. This might
+        #be usable for non-test code (i.e. no need to restart the
+        #script over and over again)?
+        sync_count += 1
+        log.debug("TRYING SYNC NUMBER: " + str(sync_count))
+        jm_single().bc_interface.sync_wallet(wallet)
+        #avoid infinite loop on failure.
+        assert sync_count < 10
+
+    #validate the wallet index values after sync
+    for i, ws in enumerate(wallet_structure):
+        assert wallet.index[i][0] == ws #spends into external only
+    #Same number as above; note it includes the spammer's extras.
+    assert wallet.index[0][1] == num_txs+fake_count*2*num_txs
+    assert wallet.index[1][1] == num_txs #one change per transaction
+    for i in range(2,5):
+        assert wallet.index[i][1] == 0 #unused
+
+    #Now try to do more transactions as sanity check.
+    do_tx(wallet, 50000000)
 
 @pytest.mark.parametrize(
     "pwd, in_privs",
@@ -28,10 +138,11 @@ log = get_log()
                         "Kz6UJmQACJmLtaQj5A3JAge4kVTNQ8gbvXuwbmCj7bsaabudb3RD"]
          ),
     ])
-def test_import_privkey(setup_wallets, setup_import, pwd, in_privs):
+def test_import_privkey(setup_wallets, pwd, in_privs):
     """This tests successful import of WIF compressed private keys
     into the wallet for mainnet.
     """
+    setup_import()
     test_in = [pwd, ' '.join(in_privs)]
     expected = ['Enter wallet decryption passphrase:',
                 'to import:']
@@ -44,14 +155,13 @@ def test_import_privkey(setup_wallets, setup_import, pwd, in_privs):
     #p.close()
     testlog.close()
 
-@pytest.fixture(scope='function')
-def setup_import(request):
+def setup_import(mainnet=True):
     try:
         os.remove("wallets/test_import_wallet.json")
     except:
         pass
-    #generate a new *mainnet* wallet
-    jm_single().config.set("BLOCKCHAIN", "network", "mainnet")
+    if mainnet:
+        jm_single().config.set("BLOCKCHAIN", "network", "mainnet")
     pwd = 'import-pwd'
     test_in = [pwd, pwd, 'test_import_wallet.json']
     expected = ['Enter wallet encryption passphrase:',
@@ -69,10 +179,7 @@ def setup_import(request):
         print f.read()
     if p.exitstatus != 0:
         raise Exception('failed due to exit status: ' + str(p.exitstatus))
-    def import_teardown():
-        jm_single().config.set("BLOCKCHAIN", "network", "testnet")
-    request.addfinalizer(import_teardown)
-
+    jm_single().config.set("BLOCKCHAIN", "network", "testnet")
 
 @pytest.mark.parametrize(
     "nw, wallet_structures, mean_amt, sdev_amt, amount",


### PR DESCRIPTION
… testing features for sync

This was motivated by problems people were having with sync, but the main point is not really that: the change in `blockchaininterface` here is addressing this condition: addresses are requested in a yield generator in `CoinJoinOrder.__init__` which are not used, the index cache is updated. On restart, the syncing process as-was would correctly wait until the index_cache value was reached, but at the end would assign the index to the `last_used_addr+1`, where `last_used_addr` is coming from the rpc `listtransactions`, i.e. addresses actually used in transactions, not accounting for the fact that the index (and cache) had been updated to a higher number due to the requests. This change now sets the index to the index cache value in cases where it's higher than the `last_used_addr`.

I'll cross apply the change to blockr if there's agreement. Probably just add one more commit.

There are other points to mention here, I'll make separate comments.