### PR TITLE
adds --show-xpub option to display wallet xpub and for each mix level.

### DIFF
--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -139,13 +139,13 @@ class Wallet(AbstractWallet):
         if extend_mixdepth and len(self.index_cache) > max_mix_depth:
             self.max_mix_depth = len(self.index_cache)
         self.gaplimit = gaplimit
-        master = btc.bip32_master_key(self.seed, (btc.MAINNET_PRIVATE if
+        self.master_key = btc.bip32_master_key(self.seed, (btc.MAINNET_PRIVATE if
             get_network() == 'mainnet' else btc.TESTNET_PRIVATE))
-        m_0 = btc.bip32_ckd(master, 0)
-        mixing_depth_keys = [btc.bip32_ckd(m_0, c)
+        m_0 = btc.bip32_ckd(self.master_key, 0)
+        self.mixing_depth_keys = [btc.bip32_ckd(m_0, c)
                              for c in range(self.max_mix_depth)]
         self.keys = [(btc.bip32_ckd(m, 0), btc.bip32_ckd(m, 1))
-                     for m in mixing_depth_keys]
+                     for m in self.mixing_depth_keys]
         self.init_index()
 
     def init_index(self):

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -59,6 +59,11 @@ parser.add_option('--csv',
                   dest='csv',
                   default=False,
                   help=('When using the history method, output as csv'))
+parser.add_option('--show-xpub',
+                  action='store_true',
+                  dest='showxpub',
+                  default=False,
+                  help=('Display master xpub key for wallet and each mix level'))
 (options, args) = parser.parse_args()
 
 # if the index_cache stored in wallet.json is longer than the default
@@ -108,17 +113,18 @@ if method == 'display' or method == 'displayall' or method == 'summary':
         if method != 'summary':
             print(s)
 
+    if options.showxpub:
+        cus_print('wallet xpub: %s' % (btc.bip32_privtopub(wallet.master_key)))
+
     total_balance = 0
     for m in range(wallet.max_mix_depth):
         cus_print('mixing depth %d m/0/%d/' % (m, m))
+        if options.showxpub:
+            cus_print(' xpub: %s' % (btc.bip32_privtopub(wallet.mixing_depth_keys[m])))
         balance_depth = 0
         for forchange in [0, 1]:
-            if forchange == 0:
-                xpub_key = btc.bip32_privtopub(wallet.keys[m][forchange])
-            else:
-                xpub_key = ''
             cus_print(' ' + ('external' if forchange == 0 else 'internal') +
-                      ' addresses m/0/%d/%d' % (m, forchange) + ' ' + xpub_key)
+                      ' addresses m/0/%d/%d' % (m, forchange) )
 
             for k in range(wallet.index[m][forchange] + options.gaplimit):
                 addr = wallet.get_addr(m, forchange, k)


### PR DESCRIPTION
This pull request addresses issue #573.

User facing changes:
- new flag --show-xpub  "Display master xpub key for wallet and each mix level"
-  if flag is present:
     1. wallet xpub is displayed first with label: "wallet xpub:"
     2. mixlevel xpub is displayed before addresses with label: "xpub:".
- if flag is not present, no xpub are displayed, not even for external addresses.

note: This pull request removes the display of xpub for external addresses (m/0/x/0).  In my judgement, that info is mostly redundant to m/0/x xpub and clutters up the screen.   A possible enhancement could be to add a verbosity level to the --show-xpub flag, in which case it could print xpub for both m/0/x/0 and m/0/x/1.   Or we could simply keep the previous behavior.

note:  This pull request intentionally does not address display of xpriv keys as there are potentially more privacy issues around that, and it could easily be implented with a separate flag, eg --show-xpriv.

Let me know your thoughts.
