### PR TITLE
Wallet sync imports at least what is in index_cache, reducing number …

### DIFF
--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -586,7 +586,7 @@ class BitcoinCoreInterface(BlockchainInterface):
 		#In cases where the Bitcoin Core instance is fresh,
 		#this will allow the entire import+rescan to occur
 		#in 2 steps only.
-		if wallet.index_cache != [[0,0]]*5:
+		if wallet.index_cache != [[0,0]]*wallet.max_mix_depth:
 		    #Need to request N*addr_req_count where N is least s.t.
 		    #N*addr_req_count > index_cache val. This is so that the batching
 		    #process in the main loop *always* has already imported enough


### PR DESCRIPTION
…of restarts needed for initial sync in some contexts.

Basically, the initial section of the sync_addresses code no longer just imports addr_req_count for each branch, but rather the minimum multiple of addr_req_count that is larger than what is in the index_cache (if it exists - if not, the behaviour is unchanged).

Generally this should improve the specific situation in which the user has a wallet.json file with an index_cache, but does not have the required addresses imported into the Bitcoin Core wallet. I expect that if using an existing wallet.json file on a fresh Core instance, 2 steps should be required only: run wallet-tool, do rescan, then run wallet-tool again only once (because all necessary addresses should be imported in one step.

Some extra tests added. @raedah or anyone else, if you have a scenario you can easily test, please do so, thanks.