### PR TITLE
fix crash on short/null privmsg

### DIFF
--- a/joinmarket/irc.py
+++ b/joinmarket/irc.py
@@ -261,6 +261,9 @@ class IRCMessageChannel(MessageChannel):
 
     def __handle_privmsg(self, source, target, message):
         nick = get_irc_nick(source)
+        #ensure return value 'parsed' is length > 2
+        if len(message) < 4:
+            return
         if target == self.nick:
             if message[0] == '\x01':
                 endindex = message[1:].find('\x01')

--- a/joinmarket/message_channel.py
+++ b/joinmarket/message_channel.py
@@ -267,6 +267,14 @@ class MessageChannel(object):
 
     def on_privmsg(self, nick, message):
         """handles the case when a private message is received"""
+        #Aberrant short messages should be handled by subclasses
+        #in _privmsg, but this constitutes a sanity check. Note that
+        #messages which use an encrypted_command but present no
+        #ciphertext will be rejected with the ValueError on decryption.
+        #Other ill formatted messages will be caught in the try block.
+        if len(message) < 2:
+            return
+
         if message[0] != COMMAND_PREFIX:
             log.debug('message not a cmd')
             return

--- a/test/test_irc_messaging.py
+++ b/test/test_irc_messaging.py
@@ -82,6 +82,8 @@ def test_junk_messages(setup_messaging):
     #send a fill with an invalid pubkey to the existing yg;
     #this should trigger a NaclError but should NOT kill it.
     mc._privmsg(yg_name, "fill", "0 10000000 abcdef")
+    #Test that null privmsg does not cause crash; TODO check maker log?
+    mc.send_raw("PRIVMSG " + yg_name + " :")
     time.sleep(1)
     #try:
     with pytest.raises(CJPeerError) as e_info:


### PR DESCRIPTION
After reports via IRC: receiving privmsgs with 0 length can cause crash; also noticed it will also be possible if message after parsing trailers may cause a crash in on_privmsg in messagechannel. Added checks for this.
