### PR TITLE
Log testnet as well, to different file

### DIFF
--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -40,7 +40,11 @@ log = get_log()
 # spent from utxos that try to make the highest balance even higher
 # so try to keep coins concentrated in one mixing depth
 class YieldGenerator(Maker):
-    statement_file = os.path.join('logs', 'yigen-statement.csv')
+    @property
+    def statement_file(self):
+        suffix = '-test' if get_network() == 'testnet' else ''
+        filename = 'yigen-statement{0}.csv'.format(suffix)
+        return os.path.join('logs', filename)
 
     def __init__(self, msgchan, wallet):
         Maker.__init__(self, msgchan, wallet)
@@ -50,9 +54,6 @@ class YieldGenerator(Maker):
         self.tx_unconfirm_timestamp = {}
 
     def log_statement(self, data):
-        if get_network() == 'testnet':
-            return
-
         data = [str(d) for d in data]
         self.income_statement = open(self.statement_file, 'a')
         self.income_statement.write(','.join(data) + '\n')

--- a/yield-generator-deluxe.py
+++ b/yield-generator-deluxe.py
@@ -130,7 +130,11 @@ def drange(start, stop, step):
 
 
 class YieldGenerator(Maker):
-    statement_file = os.path.join('logs', 'yigen-statement.csv')
+    @property
+    def statement_file(self):
+        suffix = '-test' if get_network() == 'testnet' else ''
+        filename = 'yigen-statement{0}.csv'.format(suffix)
+        return os.path.join('logs', filename)
 
     def __init__(self, msgchan, wallet):
         Maker.__init__(self, msgchan, wallet)
@@ -140,9 +144,6 @@ class YieldGenerator(Maker):
         self.tx_unconfirm_timestamp = {}
 
     def log_statement(self, data):
-        if get_network() == 'testnet':
-            return
-
         data = [str(d) for d in data]
         self.income_statement = open(self.statement_file, 'a')
         self.income_statement.write(','.join(data) + '\n')

--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -52,7 +52,11 @@ log = get_log()
 #announce an absolute fee order between the dust limit and minimum amount
 # so that there is liquidity in the very low amounts too
 class YieldGenerator(Maker):
-    statement_file = os.path.join('logs', 'yigen-statement.csv')
+    @property
+    def statement_file(self):
+        suffix = '-test' if get_network() == 'testnet' else ''
+        filename = 'yigen-statement{0}.csv'.format(suffix)
+        return os.path.join('logs', filename)
 
     def __init__(self, msgchan, wallet):
         Maker.__init__(self, msgchan, wallet)
@@ -62,9 +66,6 @@ class YieldGenerator(Maker):
         self.tx_unconfirm_timestamp = {}
 
     def log_statement(self, data):
-        if get_network() == 'testnet':
-            return
-
         data = [str(d) for d in data]
         self.income_statement = open(self.statement_file, 'a')
         self.income_statement.write(','.join(data) + '\n')


### PR DESCRIPTION
I would like to see testnet transactions logged as well. In this patch I use a property, but I guess setting the `statement_file` attribute in `__init__` would be considered cleaner? I can do it either way and update the other yigen scripts as well if this change is OK.
