### PR TITLE
made irc code detect network name and use it for hostid

### DIFF
--- a/joinmarket/irc.py
+++ b/joinmarket/irc.py
@@ -368,18 +368,18 @@ class IRCMessageChannel(MessageChannel):
             nick = get_irc_nick(_chunks[0])
             if self.on_nick_leave:
                 self.on_nick_leave(nick, self)
-
-        # todo: cleanup
-        # elif _chunks[1] == 'JOIN':
-        #     channel = _chunks[2][1:]
-        #     nick = get_irc_nick(_chunks[0])
-        #
-        # elif chunks[1] == '005':
-        #     self.motd_fd = open("motd.txt", "w")
-        # elif chunks[1] == '372':
-        #     self.motd_fd.write(get_irc_text(line) + "\n")
-        # elif chunks[1] == '251':
-        #     self.motd_fd.close()
+        elif _chunks[1] == '005':
+            ##:port80b.se.quakenet.org 005 J5BzJGGfyw5GaPc MAXNICKLEN=15
+            ##TOPICLEN=250 AWAYLEN=160 KICKLEN=250 CHANNELLEN=200
+            ##MAXCHANNELLEN=200 CHANTYPES=#& PREFIX=(ov)@+ STATUSMSG=@+
+            ##CHANMODES=b,k,l,imnpstrDducCNMT CASEMAPPING=rfc1459
+            ##NETWORK=QuakeNet :are supported by this server
+            parameter_chunk = line[line.find(_chunks[2]) + len(_chunks[2]) + 1
+                : line[1:].find(':')]
+            for params in parameter_chunk.split(' '):
+                if params.lower().startswith('network='):
+                    self.hostid = params[8:]
+                    log.debug('found network name: ' + self.hostid + ';')
 
     def __init__(self,
                  configdata,
@@ -389,7 +389,8 @@ class IRCMessageChannel(MessageChannel):
         MessageChannel.__init__(self)
         self.give_up = True
         self.serverport = (configdata['host'], configdata['port'])
-        self.hostid = configdata['hostid']
+        #default hostid for use with miniircd which doesnt send NETWORK
+        self.hostid = configdata['host'] + str(configdata['port'])
         self.socks5 = configdata["socks5"]
         self.usessl = configdata["usessl"]
         self.socks5_host = configdata["socks5_host"]


### PR DESCRIPTION
PR which automatically detects the IRC network name and puts it into self.hostid in MessageChannel.

miniircd doesn't send the NETWORK parameter so to keep our tests working, self.hostid is initalized by data from the host and port, which is then overwritten.