### PR TITLE
Quote csv values of wallet-history script

### DIFF
--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -444,7 +444,7 @@ elif method == 'history':
             skip_n1(mixdepth_dst)]
         if options.csv:
             printable_data += [tx['txid']]
-        l = s().join(printable_data)
+        l = s().join(map('"{}"'.format, printable_data))
         print(l)
 
         if tx_type != 'cj internal':


### PR DESCRIPTION
mixdepth-from and mixdepth-to can be tuples, their string representation
contains commas, breaking the csv output for many use cases. Quote all
fields to prevent this and future inconsistencies.