### PR TITLE
Mixdepth orders improvement

### DIFF
--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -146,10 +146,9 @@ class YieldGenerator(Maker):
         log.debug('generated orders = \n' + '\n'.join([str(o) for o in orders]))
 
         # sanity check
-        for order in orders:
-            assert order['minsize'] >= 0
-            assert order['maxsize'] > 0
-            assert order['minsize'] <= order['maxsize']
+        for order in orders[:]:
+            if order['minsize'] < 0 or order['maxsize'] <= 0 or order['minsize'] > order['maxsize']:
+                orders.remove(order)
 
         return orders
 

--- a/yield-generator-mixdepth.py
+++ b/yield-generator-mixdepth.py
@@ -182,6 +182,7 @@ class YieldGenerator(Maker):
                     break
 
         # Re-enumerate orders
+        orders.sort(key=lambda y: y['cjfee'])
         for i, order in enumerate(orders):
             order['oid'] = i
 


### PR DESCRIPTION
I found 2 issues:
1. if I change some parameters (e.g. DUST_THRESHOLD) the orders generator creates invalid orders. Now the sanity check deletes the invalid orders instead break all with an assert;
2. If more mixdepths have the same fee (e.g. `cjfee = ['0.0001', '0.0001', '0.0001', '0.00005', '0.00005']`) it is possible to join the orders with the same cjfee, improving the privacy