### PR TITLE
Windows specific fix to allow bots to run with secp256k1 binding.

### DIFF
--- a/bitcoin/secp256k1_main.py
+++ b/bitcoin/secp256k1_main.py
@@ -306,7 +306,12 @@ def ecdsa_raw_sign(msg,
         nf = ffi.addressof(_noncefunc.lib, "nonce_function_rand")
         ndata = ffi.new("char [32]", usenonce)
         usenonce = (nf, ndata)
-    sig = newpriv.ecdsa_sign(msg, raw=rawmsg, custom_nonce=usenonce)
+    if usenonce:
+        sig = newpriv.ecdsa_sign(msg, raw=rawmsg, custom_nonce=usenonce)
+    else:
+        #partial fix for secp256k1-transient not including customnonce;
+        #partial because donations will crash on windows in the "if".
+        sig = newpriv.ecdsa_sign(msg, raw=rawmsg)
     return newpriv.ecdsa_serialize(sig)
 
 @hexbin


### PR DESCRIPTION
Note that this is only a partial fix, since bots will crash if they try to execute the donation code (i.e. if choosing non-zero donation as tumbler). Complete fix therefore requires that the underlying secp256k1 binding is up to date with at least 0.13.1, which includes the custom_nonce PR.