### PR TITLE
Add gaplimit option for yield generators.

### DIFF
--- a/joinmarket/yieldgenerator.py
+++ b/joinmarket/yieldgenerator.py
@@ -77,7 +77,7 @@ class YieldGenerator(Maker):
 
 
 def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer',
-           nickserv_password='', minsize=100000, mix_levels=5):
+           nickserv_password='', minsize=100000, mix_levels=5, gaplimit=6):
     import sys
 
     parser = OptionParser(usage='usage: %prog [options] [wallet file]')
@@ -99,6 +99,9 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
     parser.add_option('-m', '--mixlevels', action='store', type='int',
                       dest='mixlevels', default=mix_levels,
                       help='number of mixdepths to use')
+    parser.add_option('-g', '--gap-limit', action='store', type="int",
+                      dest='gaplimit', default=6,
+                      help='gap limit for wallet, default=6')
     (options, args) = parser.parse_args()
     if len(args) < 1:
         parser.error('Needs a wallet')
@@ -138,7 +141,7 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
         if ret[0] != 'y':
             return
 
-    wallet = Wallet(seed, max_mix_depth=mix_levels)
+    wallet = Wallet(seed, max_mix_depth=mix_levels, gaplimit=gaplimit)
     jm_single().bc_interface.sync_wallet(wallet)
 
     log.debug('starting yield generator')

--- a/yg-pe.py
+++ b/yg-pe.py
@@ -18,6 +18,7 @@ ordertype = 'reloffer'
 nickserv_password = ''
 minsize = 100000
 mix_levels = 5
+gaplimit = 6
 
 
 log = get_log()
@@ -173,5 +174,5 @@ if __name__ == "__main__":
     ygmain(YieldGeneratorPrivEnhance, txfee=txfee,
            cjfee_a=cjfee_a, cjfee_r=cjfee_r,
            ordertype=ordertype, nickserv_password=nickserv_password,
-           minsize=minsize, mix_levels=mix_levels)
+           minsize=minsize, mix_levels=mix_levels, gaplimit=gaplimit)
     print('done')

--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -18,6 +18,7 @@ ordertype = 'reloffer'
 nickserv_password = ''
 minsize = 100000
 mix_levels = 5
+gaplimit = 6
 
 log = get_log()
 
@@ -129,5 +130,5 @@ if __name__ == "__main__":
     ygmain(YieldGeneratorBasic, txfee=txfee, cjfee_a=cjfee_a,
            cjfee_r=cjfee_r, ordertype=ordertype,
            nickserv_password=nickserv_password,
-           minsize=minsize, mix_levels=mix_levels)
+           minsize=minsize, mix_levels=mix_levels, gaplimit=gaplimit)
     print('done')


### PR DESCRIPTION
Add a new option `-g` (as with `wallet-tool.py`) for the yield generators that allows controlling the gap limit used in the underlying wallet.