### PR TITLE
Taker optionally completes non-sweep transactions with a subset of makers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,7 @@ omit =
  test/tumbler-test.py
  test/test_tumbler.py
  test/test_donations.py
+ test/ygrunner.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,10 @@
 *.swp
 .cache/
 .coverage
+.DS_Store
+blacklist
 blockchain.cache
+cmttools/commitments.json
 env
 htmlcov/
 joinmarket.cfg
-cmttools/commitments.json
-blacklist
-

--- a/README.md
+++ b/README.md
@@ -61,11 +61,27 @@ The installation is slightly changed, with the secp256k1 python binding no longe
 
 1. `sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install python libsodium-dev python-pip -y`
 2. Download JoinMarket 0.2.1 source from the [releases page](https://github.com/joinmarket-org/joinmarket/releases/tag/v0.2.1) or [this direct link to v0.2.1](https://github.com/JoinMarket-Org/joinmarket/archive/v0.2.1.tar.gz)
-3. `sudo pip install -r requirements.txt`
-3. `sudo apt-get install python-matplotlib -y` (optional)
-4. Extract with `tar xzf v0.2.1.tar.gz` and then `cd joinmarket-0.2.1`
-4. Generating your first wallet will populate the configuration file: `joinmarket.cfg`.
+3. Extract with `tar xzf joinmarket-0.2.1.tar.gz` and then `cd joinmarket-0.2.1`
+4. `sudo pip install -r requirements.txt`
+5. Generating your first wallet (`python wallet-tool.py generate`) will populate the configuration file: `joinmarket.cfg`.
    Check if the default settings suit your needs.
+   
+###TAILS QUICK INSTALL FOR USERS:
+Tested up to TAILS version 2.6, but future versions likely will work as well.
+
+1. Make sure that you choose 'more options' when booting up tails and set an administrator password.
+2. `sudo apt-get update -y`
+3. `sudo apt-get install build-essential automake libtool pkg-config libffi-dev python-dev python libsodium-dev python-pip -y`
+4. Download JoinMarket 0.2.1 source from the [releases page](https://github.com/joinmarket-org/joinmarket/releases/tag/v0.2.1) or [this direct link to v0.2.1](https://github.com/JoinMarket-Org/joinmarket/archive/v0.2.1.tar.gz):
+   `wget https://github.com/JoinMarket-Org/joinmarket/archive/v0.2.1.tar.gz`
+5. Extract with `tar xzf joinmarket-0.2.1.tar.gz` and then `cd joinmarket-0.2.1`
+6. `sudo torsocks pip install -r requirements.txt`
+7. `sudo chmod -R ugo+rX /usr/local/lib/python2.7/dist-packages/`
+8. `sudo cp -r /usr/local/lib/python2.7/dist-packages/libnacl .`
+9. `sudo chown -R amnesia:amnesia libnacl`
+10. Generating your first wallet (`torify python wallet-tool.py generate`) will populate the configuration file: `joinmarket.cfg`.
+   Check if the default settings suit your needs.
+11. Prepend commands with `torify`, i.e. `torify python sendpayment.py ...`
 
 ###[INSTALL FOR WINDOWS USERS](https://github.com/JoinMarket-Org/joinmarket/wiki/Installing-JoinMarket-on-Windows)
 

--- a/README.md
+++ b/README.md
@@ -51,18 +51,19 @@ The installation is slightly changed, with the secp256k1 python binding no longe
     Try running the below without following those instructions, most likely it will fail and you will then have to follow them.
 
     ```
-    pip install -r requirements.txt
+    sudo pip install -r requirements.txt
     ```
-
+    (if you did setup 'virtualenv' mentioned above, you can omit the 'sudo')
+    
 + Matplotlib for displaying the graphs in orderbook-watcher (optional)
 
 ###DEBIAN / UBUNTU QUICK INSTALL FOR USERS:
 
-1. `sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install python libsodium-dev -y`
-2. `pip install -r requirements.txt`
-2. `sudo apt-get install python-matplotlib -y` (optional)
-3. Download JoinMarket 0.2.1 source from [here](https://github.com/joinmarket-org/joinmarket/releases/tag/v0.2.1)
-4. Extract or unzip and `cd joinmarket-0.2.1`
+1. `sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install python libsodium-dev python-pip -y`
+2. Download JoinMarket 0.2.1 source from the [releases page](https://github.com/joinmarket-org/joinmarket/releases/tag/v0.2.1) or [this direct link to v0.2.1](https://github.com/JoinMarket-Org/joinmarket/archive/v0.2.1.tar.gz)
+3. `sudo pip install -r requirements.txt`
+3. `sudo apt-get install python-matplotlib -y` (optional)
+4. Extract with `tar xzf v0.2.1.tar.gz` and then `cd joinmarket-0.2.1`
 4. Generating your first wallet will populate the configuration file: `joinmarket.cfg`.
    Check if the default settings suit your needs.
 

--- a/bitcoin/bci.py
+++ b/bitcoin/bci.py
@@ -2,7 +2,9 @@
 import json, re
 import random
 import sys
+import time
 import platform
+from joinmarket.support import get_log
 if platform.system() == "Windows":
     import ssl
     import urllib2
@@ -11,6 +13,8 @@ else:
         from urllib.request import build_opener
     except:
         from urllib2 import build_opener
+
+log = get_log()
 
 # Makes a request to a given URL (first arg) and optional params (second arg)
 def make_request(*args):
@@ -30,6 +34,17 @@ def make_request(*args):
         except:
             p = e
         raise Exception(p)
+
+def make_request_blockr(*args):
+    counter = 0
+    while True:
+        data = json.loads(make_request(*args))
+        if data['status'] == 'error' and data['code'] == 429:
+            log.debug('Blockr service error: ' + data['message'])
+            time.sleep(min(60, 2**counter / 2.))
+            counter += 1
+            continue
+        return data
 
 # Pushes a transaction to the network using https://blockchain.info/pushtx
 def bci_pushtx(tx):

--- a/bitcoin/bci.py
+++ b/bitcoin/bci.py
@@ -40,7 +40,7 @@ def make_request_blockr(*args):
     while True:
         data = json.loads(make_request(*args))
         if data['status'] == 'error' and data['code'] == 429:
-            log.debug('Blockr service error: ' + data['message'])
+            log.error('Blockr service error: ' + data['message'])
             time.sleep(min(60, 2**counter / 2.))
             counter += 1
             continue

--- a/broadcast-tx.py
+++ b/broadcast-tx.py
@@ -8,7 +8,6 @@ import time
 
 from joinmarket import OrderbookWatch, load_program_config, IRCMessageChannel
 from joinmarket import jm_single, MessageChannelCollection
-from joinmarket import random_nick
 from joinmarket import get_log, debug_dump_object, get_irc_mchannels
 
 log = get_log()
@@ -69,11 +68,10 @@ def main():
     txhex = args[0]
 
     load_program_config()
-    jm_single().nickname = random_nick()
-    log.debug('starting broadcast-tx')
-    mcs = [IRCMessageChannel(c, jm_single().nickname) for c in get_irc_mchannels()]
+    mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
     taker = Broadcaster(mcc, options.waittime, txhex)
+    log.debug('starting broadcast-tx')
     try:
         log.debug('starting message channels')
         mcc.run()

--- a/broadcast-tx.py
+++ b/broadcast-tx.py
@@ -26,7 +26,7 @@ class BroadcastThread(threading.Thread):
             'SELECT DISTINCT counterparty FROM orderbook ORDER BY RANDOM() LIMIT 1;'
         ).fetchone()
         counterparty = crow['counterparty']
-        log.debug('sending tx to ' + counterparty)
+        log.info('sending tx to ' + counterparty)
         self.taker.msgchan.push_tx(counterparty, self.taker.txhex)
         time.sleep(30) #wait for the irc throttle thread to send everything
         #when the tx notify callback is written, use that instead of a hardcoded wait
@@ -71,12 +71,12 @@ def main():
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
     taker = Broadcaster(mcc, options.waittime, txhex)
-    log.debug('starting broadcast-tx')
+    log.info('starting broadcast-tx')
     try:
-        log.debug('starting message channels')
+        log.info('starting message channels')
         mcc.run()
     except:
-        log.debug('CRASHING, DUMPING EVERYTHING')
+        log.warn('CRASHING, DUMPING EVERYTHING')
         debug_dump_object(taker)
         import traceback
         log.debug(traceback.format_exc())

--- a/cmttools/add-utxo.py
+++ b/cmttools/add-utxo.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.dirname(script_dir))
 from optparse import OptionParser
 import bitcoin as btc
 from joinmarket import load_program_config, jm_single, get_p2pk_vbyte
-from joinmarket import Wallet
+from joinmarket import Wallet, sync_wallet
 from commitment_utils import get_utxo_info, validate_utxo_data, quit
 
 def add_external_commitments(utxo_datas):
@@ -144,6 +144,12 @@ def main():
         help='only validate the provided utxos (file or command line), not add',
         default=False
     )
+    parser.add_option('--fast',
+                      action='store_true',
+                      dest='fastsync',
+                      default=False,
+                      help=('choose to do fast wallet sync, only for Core and '
+                      'only for previously synced wallet'))
     (options, args) = parser.parse_args()
     load_program_config()
     utxo_data = []
@@ -172,7 +178,7 @@ def main():
                             options.maxmixdepth,
                             options.gaplimit)
         os.chdir(os.path.join(os.getcwd(), 'cmttools'))
-        jm_single().bc_interface.sync_wallet(wallet)
+        sync_wallet(wallet, fast=options.fastsync)
         unsp = {}
         for u, av in wallet.unspent.iteritems():
                     addr = av['address']

--- a/cmttools/sendtomany.py
+++ b/cmttools/sendtomany.py
@@ -38,7 +38,7 @@ def sign(utxo, priv, destaddrs):
     share = int((amt - estfee) / len(destaddrs))
     fee = amt - share*len(destaddrs)
     assert fee >= estfee
-    log.debug("Using fee: " + str(fee))
+    log.info("Using fee: " + str(fee))
     for i, addr in enumerate(destaddrs):
         outs.append({'address': addr, 'value': share})
     unsigned_tx = btc.mktx(ins, outs)
@@ -101,7 +101,7 @@ def main():
     log.debug("Deserialized:")
     log.debug(pformat(btc.deserialize(txsigned)))
     if raw_input('Would you like to push to the network? (y/n):')[0] != 'y':
-        log.debug("You chose not to broadcast the transaction, quitting.")
+        log.info("You chose not to broadcast the transaction, quitting.")
         return
     jm_single().bc_interface.pushtx(txsigned)
 

--- a/create-unsigned-tx.py
+++ b/create-unsigned-tx.py
@@ -56,9 +56,9 @@ class PaymentThread(threading.Thread):
                 self.taker.options.makercount, self.taker.chooseOrdersFunc,
                 self.ignored_makers)
             if not self.taker.options.answeryes:
-                log.debug('total cj fee = ' + str(total_cj_fee))
+                log.info('total cj fee = ' + str(total_cj_fee))
                 total_fee_pc = 1.0 * total_cj_fee / cjamount
-                log.debug('total coinjoin fee = ' + str(float('%.3g' % (
+                log.info('total coinjoin fee = ' + str(float('%.3g' % (
                     100.0 * total_fee_pc))) + '%')
                 sendpayment.check_high_fee(total_fee_pc)
                 if raw_input('send with these orders? (y/n):')[0] != 'y':
@@ -69,7 +69,7 @@ class PaymentThread(threading.Thread):
             orders, total_cj_fee = self.sendpayment_choose_orders(
                 self.taker.cjamount, self.taker.options.makercount)
             if not orders:
-                log.debug(
+                log.error(
                     'ERROR not enough liquidity in the orderbook, exiting')
                 return
             total_amount = self.taker.cjamount + total_cj_fee + \
@@ -88,11 +88,11 @@ class PaymentThread(threading.Thread):
         if coinjointx.all_responded:
             tx = btc.serialize(coinjointx.latest_tx)
             print 'unsigned tx = \n\n' + tx + '\n'
-            log.debug('created unsigned tx, ending')
+            log.info('created unsigned tx, ending')
             self.taker.msgchan.shutdown()
             return
         self.ignored_makers += coinjointx.nonrespondants
-        log.debug('recreating the tx, ignored_makers=' + str(
+        log.info('recreating the tx, ignored_makers=' + str(
             self.ignored_makers))
         self.create_tx()
 
@@ -119,11 +119,11 @@ class PaymentThread(threading.Thread):
             else:
                 noun = 'additional'
             total_fee_pc = 1.0 * total_cj_fee / cj_amount
-            log.debug(noun + ' coinjoin fee = ' + str(float('%.3g' % (
+            log.info(noun + ' coinjoin fee = ' + str(float('%.3g' % (
                 100.0 * total_fee_pc))) + '%')
             sendpayment.check_high_fee(total_fee_pc)
             if raw_input('send with these orders? (y/n):')[0] != 'y':
-                log.debug('ending')
+                log.info('ending')
                 self.taker.msgchan.shutdown()
                 return None, -1
         return orders, total_cj_fee
@@ -258,10 +258,10 @@ def main():
                              changeaddr, utxo_data, options, chooseOrdersFunc)
     log.debug('starting create-unsigned-tx')
     try:
-        log.debug('starting message channels')
+        log.info('starting message channels')
         mcc.run()
     except:
-        log.debug('CRASHING, DUMPING EVERYTHING')
+        log.warn('CRASHING, DUMPING EVERYTHING')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'wallet_name', 'seed'])
         debug_dump_object(taker)
         import traceback

--- a/create-unsigned-tx.py
+++ b/create-unsigned-tx.py
@@ -252,7 +252,6 @@ def main():
         chooseOrdersFunc = weighted_order_choose
 
     wallet = AbstractWallet()
-    wallet.unspent = None
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
     taker = CreateUnsignedTx(mcc, wallet, cjamount, destaddr,

--- a/create-unsigned-tx.py
+++ b/create-unsigned-tx.py
@@ -13,7 +13,7 @@ from optparse import OptionParser
 # import common
 from joinmarket import taker as takermodule
 from joinmarket import load_program_config, validate_address, \
-    jm_single, get_p2pk_vbyte, random_nick
+    jm_single, get_p2pk_vbyte
 from joinmarket import get_log, choose_sweep_orders, choose_orders, \
     pick_order, cheapest_order_choose, weighted_order_choose
 from joinmarket import AbstractWallet, IRCMessageChannel, debug_dump_object, \
@@ -251,14 +251,13 @@ def main():
     else:  # choose randomly (weighted)
         chooseOrdersFunc = weighted_order_choose
 
-    log.debug('starting sendpayment')
-
     wallet = AbstractWallet()
     wallet.unspent = None
-    mcs = [IRCMessageChannel(c, jm_single().nickname) for c in get_irc_mchannels()]
+    mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
     taker = CreateUnsignedTx(mcc, wallet, cjamount, destaddr,
                              changeaddr, utxo_data, options, chooseOrdersFunc)
+    log.debug('starting create-unsigned-tx')
     try:
         log.debug('starting message channels')
         mcc.run()

--- a/joinmarket/__init__.py
+++ b/joinmarket/__init__.py
@@ -20,7 +20,7 @@ from .wallet import AbstractWallet, BitcoinCoreInterface, Wallet, \
 from .configure import load_program_config, jm_single, get_p2pk_vbyte, \
     get_network, jm_single, get_network, validate_address, get_irc_mchannels, \
     check_utxo_blacklist
-from .blockchaininterface import BlockrInterface, BlockchainInterface
+from .blockchaininterface import BlockrInterface, BlockchainInterface, sync_wallet
 from .yieldgenerator import YieldGenerator, ygmain
 # Set default logging handler to avoid "No handler found" warnings.
 

--- a/joinmarket/__init__.py
+++ b/joinmarket/__init__.py
@@ -8,7 +8,7 @@ from .support import get_log, calc_cj_fee, debug_dump_object, \
     rand_norm_array, rand_pow_array, rand_exp_array, joinmarket_alert, core_alert
 from .enc_wrapper import as_init_encryption, decode_decrypt, \
     encrypt_encode, init_keypair, init_pubkey, get_pubkey, NaclError
-from .irc import IRCMessageChannel, random_nick, B_PER_SEC
+from .irc import IRCMessageChannel, B_PER_SEC
 from .jsonrpc import JsonRpcError, JsonRpcConnectionError, JsonRpc
 from .maker import Maker
 from .message_channel import MessageChannel, MessageChannelCollection

--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -67,6 +67,16 @@ def is_index_ahead_of_cache(wallet, mix_depth, forchange):
     return wallet.index[mix_depth][forchange] >= wallet.index_cache[mix_depth][
         forchange]
 
+def sync_wallet(wallet, fast=False):
+    """Wrapper function to choose fast syncing where it's
+    both possible and requested.
+    """
+    if fast and (
+        isinstance(jm_single().bc_interface, BitcoinCoreInterface) or isinstance(
+                jm_single().bc_interface, RegtestBitcoinCoreInterface)):
+        jm_single().bc_interface.sync_wallet(wallet, fast=True)
+    else:
+        jm_single().bc_interface.sync_wallet(wallet)
 
 class BlockchainInterface(object):
     __metaclass__ = abc.ABCMeta
@@ -553,7 +563,7 @@ class BitcoinCoreInterface(BlockchainInterface):
     def __init__(self, jsonRpc, network):
         super(BitcoinCoreInterface, self).__init__()
         self.jsonRpc = jsonRpc
-
+        self.fast_sync_called = False
         blockchainInfo = self.jsonRpc.call("getblockchaininfo", [])
         actualNet = blockchainInfo['chain']
 
@@ -589,12 +599,79 @@ class BitcoinCoreInterface(BlockchainInterface):
             print(' otherwise just restart this joinmarket script')
             sys.exit(0)
 
+    def sync_wallet(self, wallet, fast=False):
+        #trigger fast sync if the index_cache is available
+        #(and not specifically disabled).
+        if fast and wallet.index_cache != [[0,0]] * wallet.max_mix_depth:
+            self.sync_wallet_fast(wallet)
+            self.fast_sync_called = True
+            return
+        super(BitcoinCoreInterface, self).sync_wallet(wallet)
+        self.fast_sync_called = False
+
+    def sync_wallet_fast(self, wallet):
+        """Exploits the fact that given an index_cache,
+        all addresses necessary should be imported, so we
+        can just list all used addresses to find the right
+        index values.
+        """
+        self.get_address_usages(wallet)
+        self.sync_unspent(wallet)
+
+    def get_address_usages(self, wallet):
+        """Use rpc `listaddressgroupings` to locate all used
+        addresses in the account (whether spent or unspent outputs).
+        This will not result in a full sync if working with a new
+        Bitcoin Core instance, in which case "fast" should have been
+        specifically disabled by the user.
+        """
+        from joinmarket.wallet import BitcoinCoreWallet
+        if isinstance(wallet, BitcoinCoreWallet):
+            return
+        wallet_name = self.get_wallet_name(wallet)
+        agd = self.rpc('listaddressgroupings', [])
+        #flatten all groups into a single list; then, remove duplicates
+        fagd = [tuple(item) for sublist in agd for item in sublist]
+        #"deduplicated flattened address grouping data" = dfagd
+        dfagd = list(set(fagd))
+        #for lookup, want dict of form {"address": amount}
+        used_address_dict = {}
+        for addr_info in dfagd:
+            if len(addr_info) < 3 or addr_info[2] != wallet_name:
+                continue
+            used_address_dict[addr_info[0]] = (addr_info[1], addr_info[2])
+
+        log.debug("Fast sync in progress. Got this many used addresses: " + str(
+            len(used_address_dict)))
+        #Need to have wallet.index point to the last used address
+        #and fill addr_cache.
+        #For each branch:
+        #If index value is present, collect all addresses up to index+gap limit
+        #For each address in that list, mark used if seen in used_address_dict
+        used_indices = {}
+        for md in range(wallet.max_mix_depth):
+            used_indices[md] = {}
+            for fc in [0, 1]:
+                used_indices[md][fc] = []
+                for i in range(wallet.index_cache[md][fc]+wallet.gaplimit):
+                    if wallet.get_addr(md, fc, i) in used_address_dict.keys():
+                        used_indices[md][fc].append(i)
+                        wallet.addr_cache[wallet.get_addr(md, fc, i)] = (md, fc, i)
+                if len(used_indices[md][fc]):
+                    wallet.index[md][fc] = used_indices[md][fc][-1]
+                else:
+                    wallet.index[md][fc] = 0
+                if not is_index_ahead_of_cache(wallet, md, fc):
+                    wallet.index[md][fc] = wallet.index_cache[md][fc]
+        self.wallet_synced = True
+
+
     def sync_addresses(self, wallet):
         from joinmarket.wallet import BitcoinCoreWallet
 
         if isinstance(wallet, BitcoinCoreWallet):
             return
-        log.debug('requesting wallet history')
+        log.debug('requesting detailed wallet history')
         wallet_name = self.get_wallet_name(wallet)
         #TODO It is worth considering making this user configurable:
         addr_req_count = 20

--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -155,8 +155,7 @@ class BlockrInterface(BlockchainInterface):
                     blockr_url = 'https://' + self.blockr_domain
                     blockr_url += '.blockr.io/api/v1/address/txs/'
 
-                    res = btc.make_request(blockr_url + ','.join(addrs))
-                    data = json.loads(res)['data']
+                    data = btc.make_request_blockr(blockr_url + ','.join(addrs))['data']
                     for dat in data:
                         if dat['nb_txs'] != 0:
                             last_used_addr = dat['address']
@@ -198,8 +197,7 @@ class BlockrInterface(BlockchainInterface):
 
             blockr_url = 'https://' + self.blockr_domain + \
                          '.blockr.io/api/v1/address/unspent/'
-            res = btc.make_request(blockr_url + ','.join(req))
-            data = json.loads(res)['data']
+            data = btc.make_request_blockr(blockr_url + ','.join(req))['data']
             if 'unspent' in data:
                 data = [data]
             for dat in data:
@@ -262,8 +260,8 @@ class BlockrInterface(BlockchainInterface):
                     blockr_url += '.blockr.io/api/v1/address/unspent/'
                     random.shuffle(self.output_addresses
                                   )  # seriously weird bug with blockr.io
-                    data = json.loads(btc.make_request(blockr_url + ','.join(
-                        self.output_addresses) + '?unconfirmed=1'))['data']
+                    data = btc.make_request_blockr(blockr_url + ','.join(
+                        self.output_addresses) + '?unconfirmed=1')['data']
 
                     shared_txid = None
                     for unspent_list in data:
@@ -281,8 +279,8 @@ class BlockrInterface(BlockchainInterface):
                     )  # here for some race condition bullshit with blockr.io
                     blockr_url = 'https://' + self.blockr_domain
                     blockr_url += '.blockr.io/api/v1/tx/raw/'
-                    data = json.loads(btc.make_request(blockr_url + ','.join(
-                        shared_txid)))['data']
+                    data = btc.make_request_blockr(blockr_url + ','.join(
+                        shared_txid))['data']
                     if not isinstance(data, list):
                         data = [data]
                     for txinfo in data:
@@ -310,8 +308,8 @@ class BlockrInterface(BlockchainInterface):
                         return
                     blockr_url = 'https://' + self.blockr_domain
                     blockr_url += '.blockr.io/api/v1/address/txs/'
-                    data = json.loads(btc.make_request(blockr_url + ','.join(
-                        self.output_addresses)))['data']
+                    data = btc.make_request_blockr(blockr_url + ','.join(
+                        self.output_addresses))['data']
                     shared_txid = None
                     for addrtxs in data:
                         txs = set(str(txdata['tx'])
@@ -325,8 +323,8 @@ class BlockrInterface(BlockchainInterface):
                         continue
                     blockr_url = 'https://' + self.blockr_domain
                     blockr_url += '.blockr.io/api/v1/tx/raw/'
-                    data = json.loads(btc.make_request(blockr_url + ','.join(
-                        shared_txid)))['data']
+                    data = btc.make_request_blockr(blockr_url + ','.join(
+                        shared_txid))['data']
                     if not isinstance(data, list):
                         data = [data]
                     for txinfo in data:
@@ -370,8 +368,8 @@ class BlockrInterface(BlockchainInterface):
         data = []
         for ids in txids:
             blockr_url = 'https://' + self.blockr_domain + '.blockr.io/api/v1/tx/info/'
-            blockr_data = json.loads(btc.make_request(blockr_url + ','.join(
-                ids)))['data']
+            data = btc.make_request_blockr(blockr_url + ','.join(
+                ids))['data']
             if not isinstance(blockr_data, list):
                 blockr_data = [blockr_data]
             data += blockr_data

--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -378,7 +378,7 @@ class BlockrInterface(BlockchainInterface):
         data = []
         for ids in txids:
             blockr_url = 'https://' + self.blockr_domain + '.blockr.io/api/v1/tx/info/'
-            data = btc.make_request_blockr(blockr_url + ','.join(
+            blockr_data = btc.make_request_blockr(blockr_url + ','.join(
                 ids))['data']
             if not isinstance(blockr_data, list):
                 blockr_data = [blockr_data]

--- a/joinmarket/blockchaininterface.py
+++ b/joinmarket/blockchaininterface.py
@@ -658,7 +658,7 @@ class BitcoinCoreInterface(BlockchainInterface):
                         used_indices[md][fc].append(i)
                         wallet.addr_cache[wallet.get_addr(md, fc, i)] = (md, fc, i)
                 if len(used_indices[md][fc]):
-                    wallet.index[md][fc] = used_indices[md][fc][-1]
+                    wallet.index[md][fc] = used_indices[md][fc][-1] + 1
                 else:
                     wallet.index[md][fc] = 0
                 if not is_index_ahead_of_cache(wallet, md, fc):

--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -94,19 +94,19 @@ rpc_user = bitcoin
 rpc_password = password
 
 [MESSAGING]
-host = irc.cyberguerrilla.org
-channel = joinmarket-pit
-port = 6697
-usessl = true
-socks5 = false
-socks5_host = localhost
-socks5_port = 9050
+host = irc.cyberguerrilla.org, agora.anarplex.net
+channel = joinmarket-pit, joinmarket-pit
+port = 6697, 14716
+usessl = true, true
+socks5 = false, false
+socks5_host = localhost, localhost
+socks5_port = 9050, 9050
 #for tor
-#host = 6dvj6v5imhny3anf.onion
+#host = 6dvj6v5imhny3anf.onion, cfyfz6afpgfeirst.onion
 #onion / i2p have their own ports on CGAN
-#port = 6698
-#usessl = true
-#socks5 = true
+#port = 6698, 6667
+#usessl = true, false
+#socks5 = true, true
 
 [TIMEOUT]
 maker_timeout_sec = 30

--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -54,7 +54,8 @@ class AttributeDict(object):
 global_singleton = AttributeDict()
 global_singleton.JM_VERSION = 5
 global_singleton.nickname = None
-global_singleton.DUST_THRESHOLD = 2730
+global_singleton.BITCOIN_DUST_THRESHOLD = 2730
+global_singleton.DUST_THRESHOLD = 10 * global_singleton.BITCOIN_DUST_THRESHOLD 
 global_singleton.bc_interface = None
 global_singleton.ordername_list = ['absoffer', 'reloffer']
 global_singleton.commitment_broadcast_list = ['hp2']

--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -60,6 +60,7 @@ global_singleton.bc_interface = None
 global_singleton.ordername_list = ['absoffer', 'reloffer']
 global_singleton.commitment_broadcast_list = ['hp2']
 global_singleton.maker_timeout_sec = 60
+global_singleton.minimum_makers = 2
 global_singleton.debug_file_lock = threading.Lock()
 global_singleton.debug_file_handle = None
 global_singleton.blacklist_file_lock = threading.Lock()
@@ -126,6 +127,11 @@ confirm_timeout_hours = 6
 # for most rapid dust sweeping, try merge_algorithm = greediest
 # but don't forget to bump your miner fees!
 merge_algorithm = default
+# For takers: the minimum number of makers you allow in a transaction
+# to complete, accounting for the fact that some makers might not be
+# responsive. Should be an integer >=2 for privacy, or set to 0 if you
+# want to disallow any reduction from your chosen number of makers.
+minimum_makers = 2
 # the fee estimate is based on a projection of how many satoshis
 # per kB are needed to get in one of the next N blocks, N set here
 # as the value of 'tx_fees'. This estimate is high if you set N=1, 

--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -299,17 +299,8 @@ def initialize_console_logger(log_level):
     log.info('hello joinmarket')
 
 def load_program_config():
-    # set the console log level and initialize console logger
-    try:
-        global_singleton.console_log_level = global_singleton.config.get(
-            "LOGGING", "console_log_level")
-    except (NoSectionError, NoOptionError):
-        log.info("No log level set, using default level INFO ")
-    initialize_console_logger(global_singleton.console_log_level)
-
     #set the location of joinmarket
     jmkt_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-    log.info("Joinmarket directory is: " + str(jmkt_dir))
     global_singleton.config.readfp(io.BytesIO(defaultconfig))
     jmkt_config_location = os.path.join(jmkt_dir, global_singleton.config_location)
     loadedFiles = global_singleton.config.read([jmkt_config_location])
@@ -330,6 +321,15 @@ def load_program_config():
                 raise Exception(
                         "Config file does not contain the required option: " + o +\
                         " in section: " + k)
+
+    # set the console log level and initialize console logger
+    try:
+        global_singleton.console_log_level = global_singleton.config.get(
+            "LOGGING", "console_log_level")
+    except (NoSectionError, NoOptionError):
+        log.info("No log level set, using default level INFO ")
+    initialize_console_logger(global_singleton.console_log_level)
+    log.info("Joinmarket directory is: " + str(jmkt_dir))
 
     try:
         global_singleton.maker_timeout_sec = global_singleton.config.getint(

--- a/joinmarket/irc.py
+++ b/joinmarket/irc.py
@@ -38,33 +38,6 @@ B_PER_SEC_INTERVAL = 4.0
 
 log = get_log()
 
-
-def random_nick(nick_len=9):
-    vowels = "aeiou"
-    consonants = ''.join([chr(
-        c) for c in range(
-            ord('a'), ord('z') + 1) if vowels.find(chr(c)) == -1])
-    assert nick_len % 2 == 1
-    N = (nick_len - 1) / 2
-    rnd_consonants = [consonants[random.randrange(len(consonants))]
-                      for _ in range(N + 1)]
-    rnd_vowels = [vowels[random.randrange(len(vowels))]
-                  for _ in range(N)] + ['']
-    ircnick = ''.join([i for sl in zip(rnd_consonants, rnd_vowels) for i in sl])
-    ircnick = ircnick.capitalize()
-    # not using debug because it might not know the logfile name at this point
-    print('Generated random nickname: ' + ircnick)
-    return ircnick
-    # Other ideas for random nickname generation:
-    # - weight randomness by frequency of letter appearance
-    # - u always follows q
-    # - generate different length nicks
-    # - append two or more of these words together
-    # - randomly combine phonetic sounds instead consonants, which may be two consecutive consonants
-    #  - e.g. th, dj, g, p, gr, ch, sh, kr,
-    # - neutral network that generates nicks
-
-
 def get_irc_text(line):
     return line[line[1:].find(':') + 2:]
 

--- a/joinmarket/irc.py
+++ b/joinmarket/irc.py
@@ -88,7 +88,7 @@ class ThrottleThread(threading.Thread):
                 bytes_recent = sum(len(i[0]) for i in self.msg_buffer)
                 if bytes_recent > B_PER_SEC * B_PER_SEC_INTERVAL:
                     if print_throttle_msg:
-                        log.info("Throttling triggered, with: "+str(
+                        log.debug("Throttling triggered, with: "+str(
                             bytes_recent)+ " bytes in the last "+str(
                                 B_PER_SEC_INTERVAL)+" seconds.")
                     print_throttle_msg = False
@@ -265,7 +265,7 @@ class IRCMessageChannel(MessageChannel):
                 parsed = self.built_privmsg[nick]
                 # wipe the message buffer waiting for the next one
                 del self.built_privmsg[nick]
-                log.info("<<privmsg on %s: " %
+                log.debug("<<privmsg on %s: " %
                 (self.hostid) + "nick=%s message=%s" % (nick, parsed))
                 self.on_privmsg(nick, parsed)
             elif message[-1] != ';':

--- a/joinmarket/irc.py
+++ b/joinmarket/irc.py
@@ -326,6 +326,8 @@ class IRCMessageChannel(MessageChannel):
             self.built_privmsg = {}
             if self.on_connect:
                 self.on_connect(self)
+            if self.hostid == 'agora-irc':
+                self.send_raw('PART #AGORA')
             self.send_raw('JOIN ' + self.channel)
             self.send_raw(
                 'MODE ' + self.nick + ' +B')  # marks as bots on unreal

--- a/joinmarket/message_channel.py
+++ b/joinmarket/message_channel.py
@@ -81,8 +81,8 @@ class MessageChannelCollection(object):
                 #but should not kill the bot. So, we don't raise an
                 #exception, but rather allow sending to continue, which
                 #should usually result in tx completion just timing out.
-                log.debug("Couldn't find a route to send privmsg")
-                log.debug("For counterparty: " + str(cp))
+                log.warn("Couldn't find a route to send privmsg")
+                log.warn("For counterparty: " + str(cp))
         return func_wrapper
 
     def __init__(self, mchannels):
@@ -193,7 +193,7 @@ class MessageChannelCollection(object):
             time.sleep(1)
             i += 1
             if self.give_up:
-                log.debug("Shutting down all connections")
+                log.info("Shutting down all connections")
                 break
             #feature only used for testing:
             #deliberately shutdown a connection at a certain time.
@@ -255,7 +255,7 @@ class MessageChannelCollection(object):
             self.active_channels[nick].privmsg(nick, cmd, message)
             return
         else:
-            log.debug("Failed to send message to: " + str(nick) + \
+            log.info("Failed to send message to: " + str(nick) + \
                           "; cannot find on any message channel.")
             return
 
@@ -272,7 +272,7 @@ class MessageChannelCollection(object):
             orderlines.append(COMMAND_PREFIX + order['ordertype'] + \
                     ' ' + ' '.join([str(order[k]) for k in order_keys]))
         if new_mc is not None and new_mc not in self.available_channels():
-            log.debug(
+            log.info(
                 "Tried to announce orders on an unavailable message channel.")
             return
         if nick is None:
@@ -353,7 +353,7 @@ class MessageChannelCollection(object):
                 #but might not be for the bot (tx recreation etc.)
                 #TODO look for another channel via nicks_seen.
                 #Rare case so not a high priority.
-                log.debug(
+                log.info(
                     "Cannot send transaction to nick, not active: " + nick)
                 return
             if self.active_channels[nick] not in tx_nick_sets:
@@ -441,7 +441,7 @@ class MessageChannelCollection(object):
             #Is the nick available on another channel?
             other_channels = [x for x in self.available_channels() if x != mc]
             if len(other_channels) == 0:
-                log.debug(
+                log.warn(
                     "Cannot reconnect to dropped nick, no connections available.")
                 if self.on_nick_leave:
                     self.on_nick_leave(nick)
@@ -743,7 +743,7 @@ class MessageChannel(object):
                     self.on_order_seen(self, counterparty, oid, ordertype, minsize,
                                        maxsize, txfee, cjfee)
             except IndexError as e:
-                log.warning(e)
+                log.debug(e)
                 log.debug('index error parsing chunks, possibly malformed'
                           'offer by other party. No user action required.')
                 # TODO what now? just ignore iirc
@@ -768,7 +768,7 @@ class MessageChannel(object):
                     if self.on_commitment_seen:
                         self.on_commitment_seen(counterparty, commitment)
             except IndexError as e:
-                log.warning(e)
+                log.debug(e)
                 log.debug('index error parsing chunks, possibly malformed'
                           'offer by other party. No user action required.')
             finally:
@@ -826,7 +826,7 @@ class MessageChannel(object):
             return self.cjpeer.get_crypto_box_from_nick(nick), True
 
     def send_error(self, nick, errormsg):
-        log.debug('error<%s> : %s' % (nick, errormsg))
+        log.info('error<%s> : %s' % (nick, errormsg))
         self.privmsg(nick, 'error', errormsg)
         raise CJPeerError()
 

--- a/joinmarket/message_channel.py
+++ b/joinmarket/message_channel.py
@@ -837,8 +837,8 @@ class MessageChannel(object):
         self._pubmsg(message)
 
     def privmsg(self, nick, cmd, message):
-        log.debug('>>privmsg ' + 'nick=' + nick + ' cmd=' + cmd + ' msg=' +
-                  message)
+        log.debug('>>privmsg on %s: ' %
+                  (self.hostid) + 'nick=' + nick + ' cmd=' + cmd + ' msg=' + message)
         # should we encrypt?
         box, encrypt = self.get_encryption_box(cmd, nick)
         if encrypt:

--- a/joinmarket/support.py
+++ b/joinmarket/support.py
@@ -17,8 +17,6 @@ from math import exp
 #                     format='%(asctime)s %(message)s',
 #                     dateformat='[%Y/%m/%d %H:%M:%S] ')
 
-logFormatter = logging.Formatter(
-    "%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
 log = logging.getLogger('joinmarket')
 log.setLevel(logging.DEBUG)
 
@@ -30,7 +28,6 @@ core_alert = ['']
 debug_silence = [False]
 
 
-#consoleHandler = logging.StreamHandler(stream=sys.stdout)
 class JoinMarketStreamHandler(logging.StreamHandler):
 
     def __init__(self, stream):
@@ -43,16 +40,6 @@ class JoinMarketStreamHandler(logging.StreamHandler):
             print('Core Alert Message: ' + core_alert[0])
         if not debug_silence[0]:
             super(JoinMarketStreamHandler, self).emit(record)
-
-
-consoleHandler = JoinMarketStreamHandler(stream=sys.stdout)
-consoleHandler.setFormatter(logFormatter)
-log.addHandler(consoleHandler)
-
-# log = logging.getLogger('joinmarket')
-# log.addHandler(logging.NullHandler())
-
-log.debug('hello joinmarket')
 
 
 def get_log():
@@ -273,7 +260,7 @@ def choose_orders(db, cj_amount, n, chooseOrdersBy, ignored_makers=None):
 
     counterparties = set([o['counterparty'] for o in orders])
     if n > len(counterparties):
-        log.debug(('ERROR not enough liquidity in the orderbook n=%d '
+        log.error(('ERROR not enough liquidity in the orderbook n=%d '
                    'suitable-counterparties=%d amount=%d totalorders=%d') %
                   (n, len(counterparties), cj_amount, len(orders)))
         # TODO handle not enough liquidity better, maybe an Exception
@@ -306,7 +293,7 @@ def choose_orders(db, cj_amount, n, chooseOrdersBy, ignored_makers=None):
                        if o[0]['counterparty'] != chosen_order['counterparty']]
         chosen_orders.append(chosen_order)
         total_cj_fee += chosen_fee
-    log.debug('chosen orders = \n' + '\n'.join([str(o) for o in chosen_orders]))
+    log.info('chosen orders = \n' + '\n'.join([str(o) for o in chosen_orders]))
     result = dict([(o['counterparty'], o) for o in chosen_orders])
     return result, total_cj_fee
 
@@ -351,7 +338,7 @@ def choose_sweep_orders(db,
         cjamount = int(cjamount.quantize(Decimal(1)))
         return cjamount, int(sumabsfee + sumrelfee * cjamount)
 
-    log.debug('choosing sweep orders for total_input_value = ' + str(
+    log.info('choosing sweep orders for total_input_value = ' + str(
         total_input_value) + ' n=' + str(n))
     sqlorders = db.execute('SELECT * FROM orderbook WHERE minsize <= ?;',
                            (total_input_value,)).fetchall()
@@ -369,11 +356,11 @@ def choose_sweep_orders(db,
     while len(chosen_orders) < n:
         for i in range(n - len(chosen_orders)):
             if len(orders_fees) < n - len(chosen_orders):
-                log.debug('ERROR not enough liquidity in the orderbook')
+                log.error('ERROR not enough liquidity in the orderbook')
                 # TODO handle not enough liquidity better, maybe an Exception
                 return None, 0, 0
             chosen_order, chosen_fee = chooseOrdersBy(orders_fees, n)
-            log.debug('chosen = ' + str(chosen_order))
+            log.info('chosen = ' + str(chosen_order))
             # remove all orders from that same counterparty
             orders_fees = [
                 o
@@ -388,9 +375,9 @@ def choose_sweep_orders(db,
             maxsize = c['maxsize']
             if cj_amount > maxsize or cj_amount < minsize:
                 chosen_orders.remove(c)
-    log.debug('chosen orders = \n' + '\n'.join([str(o) for o in chosen_orders]))
+    log.info('chosen orders = \n' + '\n'.join([str(o) for o in chosen_orders]))
     result = dict([(o['counterparty'], o) for o in chosen_orders])
-    log.debug('cj amount = ' + str(cj_amount))
+    log.info('cj amount = ' + str(cj_amount))
     return result, cj_amount, total_fee
 
 

--- a/joinmarket/taker.py
+++ b/joinmarket/taker.py
@@ -72,6 +72,8 @@ class CoinJoinTX(object):
         self.cjfee_total = 0
         self.maker_txfee_contributions = 0
         self.nonrespondants = list(self.active_orders.keys())
+        #The subset who actually take part in the transaction:
+        self.actual_respondants = []
         self.all_responded = False
         self.latest_tx = None
         # None means they belong to me
@@ -147,60 +149,67 @@ class CoinJoinTX(object):
         return True
 
     def recv_txio(self, nick, utxo_list, auth_pub, cj_addr, change_addr):
-        if nick not in self.nonrespondants:
-            log.debug(('recv_txio => nick={} not in '
-                       'nonrespondants {}').format(nick, self.nonrespondants))
-            return
-        self.utxos[nick] = utxo_list
-        utxo_data = jm_single().bc_interface.query_utxo_set(self.utxos[nick])
-        if None in utxo_data:
-            log.error(('ERROR outputs unconfirmed or already spent. '
-                       'utxo_data={}').format(pprint.pformat(utxo_data)))
-            # when internal reviewing of makers is created, add it here to
-            # immediately quit; currently, the timeout thread suffices.
-            return
-        #Complete maker authorization:
-        #Extract the address fields from the utxos
-        #Construct the Bitcoin address for the auth_pub field
-        #Ensure that at least one address from utxos corresponds.
-        input_addresses = [d['address'] for d in utxo_data]
-        auth_address = btc.pubkey_to_address(auth_pub, get_p2pk_vbyte())
-        if not auth_address in input_addresses:
-            log.error("ERROR maker's authorising pubkey is not included "
-                      "in the transaction: " + str(auth_address))
-            return
+        if nick:
+            if nick not in self.nonrespondants:
+                log.debug(('recv_txio => nick={} not in '
+                           'nonrespondants {}').format(nick, self.nonrespondants))
+                return
+            self.utxos[nick] = utxo_list
+            utxo_data = jm_single().bc_interface.query_utxo_set(self.utxos[nick])
+            if None in utxo_data:
+                log.error(('ERROR outputs unconfirmed or already spent. '
+                           'utxo_data={}').format(pprint.pformat(utxo_data)))
+                # when internal reviewing of makers is created, add it here to
+                # immediately quit; currently, the timeout thread suffices.
+                return
+            #Complete maker authorization:
+            #Extract the address fields from the utxos
+            #Construct the Bitcoin address for the auth_pub field
+            #Ensure that at least one address from utxos corresponds.
+            input_addresses = [d['address'] for d in utxo_data]
+            auth_address = btc.pubkey_to_address(auth_pub, get_p2pk_vbyte())
+            if not auth_address in input_addresses:
+                log.error("ERROR maker's authorising pubkey is not included "
+                          "in the transaction: " + str(auth_address))
+                return
 
-        total_input = sum([d['value'] for d in utxo_data])
-        real_cjfee = calc_cj_fee(self.active_orders[nick]['ordertype'],
-                       self.active_orders[nick]['cjfee'], self.cj_amount)
-        change_amount = (total_input - self.cj_amount -
-            self.active_orders[nick]['txfee'] + real_cjfee)
+            total_input = sum([d['value'] for d in utxo_data])
+            real_cjfee = calc_cj_fee(self.active_orders[nick]['ordertype'],
+                           self.active_orders[nick]['cjfee'], self.cj_amount)
+            change_amount = (total_input - self.cj_amount -
+                self.active_orders[nick]['txfee'] + real_cjfee)
 
-        # certain malicious and/or incompetent liquidity providers send
-        # inputs totalling less than the coinjoin amount! this leads to
-        # a change output of zero satoshis, so the invalid transaction
-        # fails harmlessly; let's fail earlier, with a clear message.
-        if change_amount < jm_single().DUST_THRESHOLD:
-            fmt = ('ERROR counterparty requires sub-dust change. No '
-                   'action required. nick={}'
-                   'totalin={:d} cjamount={:d} change={:d}').format
-            log.warn(fmt(nick, total_input, self.cj_amount, change_amount))
-            return              # timeout marks this maker as nonresponsive
+            # certain malicious and/or incompetent liquidity providers send
+            # inputs totalling less than the coinjoin amount! this leads to
+            # a change output of zero satoshis, so the invalid transaction
+            # fails harmlessly; let's fail earlier, with a clear message.
+            if change_amount < jm_single().DUST_THRESHOLD:
+                fmt = ('ERROR counterparty requires sub-dust change. No '
+                       'action required. nick={}'
+                       'totalin={:d} cjamount={:d} change={:d}').format
+                log.warn(fmt(nick, total_input, self.cj_amount, change_amount))
+                return              # timeout marks this maker as nonresponsive
 
-        self.outputs.append({'address': change_addr, 'value': change_amount})
-        fmt = ('fee breakdown for {} totalin={:d} '
-               'cjamount={:d} txfee={:d} realcjfee={:d}').format
-        log.debug(fmt(nick, total_input, self.cj_amount,
-            self.active_orders[nick]['txfee'], real_cjfee))
-        self.outputs.append({'address': cj_addr, 'value': self.cj_amount})
-        self.cjfee_total += real_cjfee
-        self.maker_txfee_contributions += self.active_orders[nick]['txfee']
-        self.nonrespondants.remove(nick)
-        if len(self.nonrespondants) > 0:
-            log.debug('nonrespondants = ' + str(self.nonrespondants))
-            return
+            self.outputs.append({'address': change_addr, 'value': change_amount})
+            fmt = ('fee breakdown for {} totalin={:d} '
+                   'cjamount={:d} txfee={:d} realcjfee={:d}').format
+            log.debug(fmt(nick, total_input, self.cj_amount,
+                self.active_orders[nick]['txfee'], real_cjfee))
+            self.outputs.append({'address': cj_addr, 'value': self.cj_amount})
+            self.cjfee_total += real_cjfee
+            self.maker_txfee_contributions += self.active_orders[nick]['txfee']
+            self.nonrespondants.remove(nick)
+            self.actual_respondants.append(nick)
+            if len(self.nonrespondants) > 0:
+                log.debug('nonrespondants = ' + str(self.nonrespondants))
+                return
+        #Note we fall through here immediately if nick is None;
+        #this is the case for recovery where we are going to do a join with
+        #less participants than originally intended.
+        assert len(self.actual_respondants) >= jm_single().config.getint("POLICY",
+                                                        "minimum_makers")
         log.info('got all parts, enough to build a tx')
-        self.nonrespondants = list(self.active_orders.keys())
+        self.nonrespondants = self.actual_respondants
 
         my_total_in = sum([va['value'] for u, va in
                            self.input_utxos.iteritems()])
@@ -405,43 +414,41 @@ class CoinJoinTX(object):
         return self.push()
 
     def recover_from_nonrespondants(self):
+
+        def restart():
+            self.end_timeout_thread = True
+            if self.finishcallback is not None:
+                self.finishcallback(self)
+                # finishcallback will check if self.all_responded is True
+                # and will know it came from here
+
         log.info('nonresponding makers = ' + str(self.nonrespondants))
         # if there is no choose_orders_recover then end and call finishcallback
         # so the caller can handle it in their own way, notable for sweeping
         # where simply replacing the makers wont work
         if not self.choose_orders_recover:
-            self.end_timeout_thread = True
-            if self.finishcallback is not None:
-                self.finishcallback(self)
+            restart()
             return
 
         if self.latest_tx is None:
-            # nonresponding to !fill, recover by finding another maker
+            # nonresponding to !fill-!auth, proceed with transaction anyway as long
+            # as number of makers is at least POLICY.minimum_makers (and not zero,
+            # i.e. disallow this kind of continuation).
             log.debug('nonresponse to !fill')
             for nr in self.nonrespondants:
                 del self.active_orders[nr]
-            new_orders, new_makers_fee = self.choose_orders_recover(
-                    self.cj_amount, len(self.nonrespondants),
-                    self.nonrespondants,
-                    self.active_orders.keys())
-            for nick, order in new_orders.iteritems():
-                self.active_orders[nick] = order
-            self.nonrespondants = list(new_orders.keys())
-            log.debug(('new active_orders = {} \nnew nonrespondants = '
-                       '{}').format(
-                    pprint.pformat(self.active_orders),
-                    pprint.pformat(self.nonrespondants)))
-            #Re-source commitment; previous attempt will have been blacklisted
-            self.get_commitment(self.input_utxos, self.cj_amount)
-            self.msgchan.fill_orders(new_orders, self.cj_amount,
-                                     self.kp.hex_pk(), self.commitment)
+            minmakers = jm_single().config.getint("POLICY", "minimum_makers")
+            if len(self.actual_respondants) >= minmakers and minmakers != 0:
+                log.info("Completing the transaction with: " + str(
+                    len(self.actual_respondants)) + " makers.")
+                self.recv_txio(None, None, None, None, None)
+            else:
+                log.info("Two few makers responded to complete, trying again.")
+                restart()
         else:
             log.debug('nonresponse to !tx')
-            # nonresponding to !tx, have to restart tx from the beginning
-            self.end_timeout_thread = True
-            if self.finishcallback is not None:
-                self.finishcallback(self)
-                # finishcallback will check if self.all_responded is True and will know it came from here
+            # have to restart tx from the beginning
+            restart()
 
     class TimeoutThread(threading.Thread):
 

--- a/joinmarket/taker.py
+++ b/joinmarket/taker.py
@@ -370,7 +370,7 @@ class CoinJoinTX(object):
         tx = btc.serialize(self.latest_tx)
         log.debug('\n' + tx)
         self.txid = btc.txhash(tx)
-        log.debug('txid = ' + self.txid)
+        log.info('txid = ' + self.txid)
         
         tx_broadcast = jm_single().config.get('POLICY', 'tx_broadcast')
         if tx_broadcast == 'self':

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -24,7 +24,7 @@ def estimate_tx_fee(ins, outs, txtype='p2pkh'):
     based on information from the blockchain interface.
     '''
     tx_estimated_bytes = btc.estimate_tx_size(ins, outs, txtype)
-    log.debug("Estimated transaction size: "+str(tx_estimated_bytes))
+    log.info("Estimated transaction size: "+str(tx_estimated_bytes))
     fee_per_kb = jm_single().bc_interface.estimate_fee_per_kb(
         jm_single().config.getint("POLICY", "tx_fees"))
     absurd_fee = jm_single().config.getint("POLICY", "absurd_fee_per_kb")
@@ -32,7 +32,7 @@ def estimate_tx_fee(ins, outs, txtype='p2pkh'):
         #This error is considered critical; for safety reasons, shut down.
         raise ValueError("Estimated fee per kB greater than absurd value: " + \
                          str(absurd_fee) + ", quitting.")
-    log.debug("got estimated tx bytes: "+str(tx_estimated_bytes))
+    log.info("got estimated tx bytes: "+str(tx_estimated_bytes))
     return int((tx_estimated_bytes * fee_per_kb)/Decimal(1000.0))
 
 class AbstractWallet(object):
@@ -250,7 +250,7 @@ class Wallet(AbstractWallet):
             # do not import in the middle of sync_wallet()
             if bc_interface.wallet_synced:
                 if bc_interface.rpc('getaccount', [addr]) == '':
-                    log.debug('importing address ' + addr + ' to bitcoin core')
+                    log.info('importing address ' + addr + ' to bitcoin core')
                     bc_interface.rpc(
                             'importaddress',
                             [addr, bc_interface.get_wallet_name(self), False])

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -43,6 +43,9 @@ class AbstractWallet(object):
 
     def __init__(self):
         self.max_mix_depth = 0
+        #some consumer scripts don't use an unspent, this marks it
+        #as specifically absent (rather than just empty).
+        self.unspent = None
         self.utxo_selector = btc.select  # default fallback: upstream
         try:
             config = jm_single().config

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -24,7 +24,7 @@ def estimate_tx_fee(ins, outs, txtype='p2pkh'):
     based on information from the blockchain interface.
     '''
     tx_estimated_bytes = btc.estimate_tx_size(ins, outs, txtype)
-    log.info("Estimated transaction size: "+str(tx_estimated_bytes))
+    log.debug("Estimated transaction size: "+str(tx_estimated_bytes))
     fee_per_kb = jm_single().bc_interface.estimate_fee_per_kb(
         jm_single().config.getint("POLICY", "tx_fees"))
     absurd_fee = jm_single().config.getint("POLICY", "absurd_fee_per_kb")
@@ -32,7 +32,7 @@ def estimate_tx_fee(ins, outs, txtype='p2pkh'):
         #This error is considered critical; for safety reasons, shut down.
         raise ValueError("Estimated fee per kB greater than absurd value: " + \
                          str(absurd_fee) + ", quitting.")
-    log.info("got estimated tx bytes: "+str(tx_estimated_bytes))
+    log.debug("got estimated tx bytes: "+str(tx_estimated_bytes))
     return int((tx_estimated_bytes * fee_per_kb)/Decimal(1000.0))
 
 class AbstractWallet(object):

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -169,6 +169,13 @@ class Wallet(AbstractWallet):
             sys.exit(0)
         if 'index_cache' in walletdata:
             self.index_cache = walletdata['index_cache']
+            if self.max_mix_depth > len(self.index_cache):
+                #This can happen e.g. in tumbler when we need more mixdepths
+                #than currently exist. Since we have no info for those extra
+                #depths, we must default to (0,0) (but sync should find used
+                #adddresses).
+                self.index_cache += [[0,0]] * (
+                    self.max_mix_depth - len(self.index_cache))
         decrypted = False
         while not decrypted:
             if pwd:

--- a/joinmarket/yieldgenerator.py
+++ b/joinmarket/yieldgenerator.py
@@ -77,7 +77,7 @@ class YieldGenerator(Maker):
 
 
 def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer',
-           nickserv_password='', minsize=100000, mix_levels=5):
+           nickserv_password='', minsize=100000, mix_levels=5, gaplimit=6):
     import sys
 
     parser = OptionParser(usage='usage: %prog [options] [wallet file]')
@@ -99,6 +99,9 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
     parser.add_option('-m', '--mixlevels', action='store', type='int',
                       dest='mixlevels', default=mix_levels,
                       help='number of mixdepths to use')
+    parser.add_option('-g', '--gap-limit', action='store', type="int",
+                      dest='gaplimit', default=6,
+                      help='gap limit for wallet, default=6')
     (options, args) = parser.parse_args()
     if len(args) < 1:
         parser.error('Needs a wallet')
@@ -138,7 +141,7 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
         if ret[0] != 'y':
             return
 
-    wallet = Wallet(seed, max_mix_depth=mix_levels)
+    wallet = Wallet(seed, max_mix_depth=mix_levels, gaplimit=gaplimit)
     jm_single().bc_interface.sync_wallet(wallet)
 
     mcs = [IRCMessageChannel(c, realname='btcint=' + jm_single().config.get(

--- a/joinmarket/yieldgenerator.py
+++ b/joinmarket/yieldgenerator.py
@@ -154,14 +154,14 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
                                  "BLOCKCHAIN", "blockchain_source"),
                         password=nickserv_password) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
-    log.debug('starting yield generator')
+    log.info('starting yield generator')
     maker = ygclass(mcc, wallet, [options.txfee, cjfee_a, cjfee_r,
                                   options.ordertype, options.minsize, mix_levels])
     try:
-        log.debug('connecting to message channels')
+        log.info('connecting to message channels')
         mcc.run()
     except:
-        log.debug('CRASHING, DUMPING EVERYTHING')
+        log.warn('CRASHING, DUMPING EVERYTHING')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
         debug_dump_object(maker)
         debug_dump_object(mcc, ['nick_priv', 'nick_pkh_raw'])

--- a/joinmarket/yieldgenerator.py
+++ b/joinmarket/yieldgenerator.py
@@ -11,7 +11,7 @@ from joinmarket import Maker, IRCMessageChannel, MessageChannelCollection
 from joinmarket import BlockrInterface
 from joinmarket import jm_single, get_network, load_program_config
 from joinmarket import get_log, calc_cj_fee, debug_dump_object
-from joinmarket import Wallet
+from joinmarket import Wallet, sync_wallet
 from joinmarket import get_irc_mchannels
 
 log = get_log()
@@ -102,6 +102,12 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
     parser.add_option('-g', '--gap-limit', action='store', type="int",
                       dest='gaplimit', default=6,
                       help='gap limit for wallet, default=6')
+    parser.add_option('--fast',
+                      action='store_true',
+                      dest='fastsync',
+                      default=False,
+                      help=('choose to do fast wallet sync, only for Core and '
+                      'only for previously synced wallet'))
     (options, args) = parser.parse_args()
     if len(args) < 1:
         parser.error('Needs a wallet')
@@ -142,7 +148,7 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
             return
 
     wallet = Wallet(seed, max_mix_depth=mix_levels, gaplimit=gaplimit)
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet, fast=options.fastsync)
 
     mcs = [IRCMessageChannel(c, realname='btcint=' + jm_single().config.get(
                                  "BLOCKCHAIN", "blockchain_source"),

--- a/joinmarket/yieldgenerator.py
+++ b/joinmarket/yieldgenerator.py
@@ -161,7 +161,7 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
         log.info('connecting to message channels')
         mcc.run()
     except:
-        log.warn('CRASHING, DUMPING EVERYTHING')
+        log.warn('Quitting! Dumping object contents to logfile.')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
         debug_dump_object(maker)
         debug_dump_object(mcc, ['nick_priv', 'nick_pkh_raw'])

--- a/ob-watcher.py
+++ b/ob-watcher.py
@@ -370,7 +370,7 @@ def main():
     hostport = (options.host, options.port)
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
-    log.debug("Starting ob-watcher")
+    log.info("Starting ob-watcher")
     # todo: is the call to GUITaker needed, or the return. taker unused
     taker = GUITaker(mcc, hostport)
     print('starting irc')

--- a/ob-watcher.py
+++ b/ob-watcher.py
@@ -19,7 +19,7 @@ from optparse import OptionParser
 import matplotlib
 
 from joinmarket import jm_single, load_program_config, MessageChannelCollection
-from joinmarket import random_nick, calc_cj_fee, OrderbookWatch, get_irc_mchannels
+from joinmarket import calc_cj_fee, OrderbookWatch, get_irc_mchannels
 from joinmarket import IRCMessageChannel, get_log
 
 log = get_log()

--- a/patientsendpayment.py
+++ b/patientsendpayment.py
@@ -116,7 +116,7 @@ class PatientSendPayment(Maker, Taker):
                      'cjfee': self.cjfee}
             return [], [order]
         else:
-            log.debug('not enough money left, have to wait until tx confirms')
+            log.warn('not enough money left, have to wait until tx confirms')
             return [0], []
 
     def on_tx_confirmed(self, cjorder, confirmations, txid, balance):
@@ -234,7 +234,7 @@ def main():
         print 'not enough money at mixdepth=%d, exiting' % options.mixdepth
         return
 
-    log.debug('Running patient sender of a payment')
+    log.info('Running patient sender of a payment')
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
     PatientSendPayment(mcc, wallet, destaddr, amount, options.makercount,
@@ -243,7 +243,7 @@ def main():
     try:
         mcc.run()
     except:
-        log.debug('CRASHING, DUMPING EVERYTHING')
+        log.warn('CRASHING, DUMPING EVERYTHING')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
         # todo: looks wrong.  dump on the class object?
         # debug_dump_object(taker)

--- a/patientsendpayment.py
+++ b/patientsendpayment.py
@@ -9,7 +9,6 @@ from optparse import OptionParser
 # sys.path.insert(0, os.path.join(data_dir, 'joinmarket'))
 from joinmarket import Maker, Taker, load_program_config, IRCMessageChannel
 from joinmarket import validate_address, jm_single
-from joinmarket import random_nick
 from joinmarket import get_log, choose_orders, weighted_order_choose, \
     debug_dump_object
 from joinmarket import Wallet
@@ -229,16 +228,14 @@ def main():
         print 'not enough money at mixdepth=%d, exiting' % options.mixdepth
         return
 
-    jm_single().nickname = random_nick()
-
     log.debug('Running patient sender of a payment')
-
-    irc = IRCMessageChannel(jm_single().nickname)
-    PatientSendPayment(irc, wallet, destaddr, amount, options.makercount,
+    mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
+    mcc = MessageChannelCollection(mcs)
+    PatientSendPayment(mcc, wallet, destaddr, amount, options.makercount,
                              options.txfee, options.cjfee, waittime,
                              options.mixdepth)
     try:
-        irc.run()
+        mcc.run()
     except:
         log.debug('CRASHING, DUMPING EVERYTHING')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])

--- a/patientsendpayment.py
+++ b/patientsendpayment.py
@@ -10,7 +10,7 @@ from optparse import OptionParser
 from joinmarket import Maker, Taker, load_program_config, IRCMessageChannel
 from joinmarket import validate_address, jm_single
 from joinmarket import get_log, choose_orders, weighted_order_choose, \
-    debug_dump_object
+    debug_dump_object, sync_wallet
 from joinmarket import Wallet
 
 log = get_log()
@@ -194,6 +194,12 @@ def main():
             help=
             'Use the Bitcoin Core wallet through json rpc, instead of the internal joinmarket '
             + 'wallet. Requires blockchain_source=json-rpc')
+    parser.add_option('--fast',
+                      action='store_true',
+                      dest='fastsync',
+                      default=False,
+                      help=('choose to do fast wallet sync, only for Core and '
+                      'only for previously synced wallet'))
     (options, args) = parser.parse_args()
 
     if len(args) < 3:
@@ -221,7 +227,7 @@ def main():
         print 'not implemented yet'
         sys.exit(0)
     # wallet = BitcoinCoreWallet(fromaccount=wallet_name)
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet, fast=options.fastsync)
 
     available_balance = wallet.get_balance_by_mixdepth()[options.mixdepth]
     if available_balance < amount:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ pexpect
 pytest==2.8.2
 pytest-cov==2.2.1
 python-coveralls
+mock
 
 -r requirements.txt

--- a/sendpayment.py
+++ b/sendpayment.py
@@ -71,8 +71,8 @@ class PaymentThread(threading.Thread):
             est_outs = 2*self.taker.makercount + 1
             log.debug("Estimated outs: "+str(est_outs))
             estimated_fee = estimate_tx_fee(est_ins, est_outs)
-            log.debug("We have a fee estimate: "+str(estimated_fee))
-            log.debug("And a requested fee of: "+str(
+            log.info("We have a fee estimate: "+str(estimated_fee))
+            log.info("And a requested fee of: "+str(
                 self.taker.txfee * self.taker.makercount))
             if estimated_fee > self.taker.makercount * self.taker.txfee:
                 #both values are integers; we can ignore small rounding errors
@@ -85,9 +85,9 @@ class PaymentThread(threading.Thread):
             if not orders:
                 raise Exception("Could not find orders to complete transaction.")
             if not self.taker.answeryes:
-                log.debug('total cj fee = ' + str(total_cj_fee))
+                log.info('total cj fee = ' + str(total_cj_fee))
                 total_fee_pc = 1.0 * total_cj_fee / cjamount
-                log.debug('total coinjoin fee = ' + str(float('%.3g' % (
+                log.info('total coinjoin fee = ' + str(float('%.3g' % (
                     100.0 * total_fee_pc))) + '%')
                 check_high_fee(total_fee_pc)
                 if raw_input('send with these orders? (y/n):')[0] != 'y':
@@ -97,7 +97,7 @@ class PaymentThread(threading.Thread):
             orders, total_cj_fee = self.sendpayment_choose_orders(
                 self.taker.amount, self.taker.makercount)
             if not orders:
-                log.debug(
+                log.error(
                     'ERROR not enough liquidity in the orderbook, exiting')
                 return
             total_amount = self.taker.amount + total_cj_fee + \
@@ -123,15 +123,15 @@ class PaymentThread(threading.Thread):
         if coinjointx.all_responded:
             pushed = coinjointx.self_sign_and_push()
             if pushed:
-                log.debug('created fully signed tx, ending')
+                log.info('created fully signed tx, ending')
             else:
                 #Error should be in log, will not retry.
-                log.debug('failed to push tx, ending.')
+                log.error('failed to push tx, ending.')
             time.sleep(10) # see github issue #516
             self.taker.msgchan.shutdown()
             return
         self.ignored_makers += coinjointx.nonrespondants
-        log.debug('recreating the tx, ignored_makers=' + str(
+        log.info('recreating the tx, ignored_makers=' + str(
             self.ignored_makers))
         self.create_tx()
 
@@ -158,11 +158,11 @@ class PaymentThread(threading.Thread):
             else:
                 noun = 'additional'
             total_fee_pc = 1.0 * total_cj_fee / cj_amount
-            log.debug(noun + ' coinjoin fee = ' + str(float('%.3g' % (
+            log.info(noun + ' coinjoin fee = ' + str(float('%.3g' % (
                 100.0 * total_fee_pc))) + '%')
             check_high_fee(total_fee_pc)
             if raw_input('send with these orders? (y/n):')[0] != 'y':
-                log.debug('ending')
+                log.info('ending')
                 self.taker.msgchan.shutdown()
                 return None, -1
         return orders, total_cj_fee
@@ -313,10 +313,10 @@ def main():
     # we guess conservatively with 2 inputs and 2 outputs each
     if options.txfee == -1:
         options.txfee = max(options.txfee, estimate_tx_fee(2, 2))
-        log.debug("Estimated miner/tx fee for each cj participant: "+str(options.txfee))
+        log.info("Estimated miner/tx fee for each cj participant: "+str(options.txfee))
     assert(options.txfee >= 0)
 
-    log.debug('starting sendpayment')
+    log.info('starting sendpayment')
 
     if not options.userpcwallet:
         wallet = Wallet(wallet_name, options.amtmixdepths, options.gaplimit)
@@ -326,15 +326,15 @@ def main():
 
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
-    log.debug("starting sendpayment")
+    log.info("starting sendpayment")
     taker = SendPayment(mcc, wallet, destaddr, amount, options.makercount,
                         options.txfee, options.waittime, options.mixdepth,
                         options.answeryes, chooseOrdersFunc)
     try:
-        log.debug('starting message channels')
+        log.info('starting message channels')
         mcc.run()
     except:
-        log.debug('CRASHING, DUMPING EVERYTHING')
+        log.warn('CRASHING, DUMPING EVERYTHING')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'wallet_name', 'seed'])
         debug_dump_object(taker)
         import traceback

--- a/sendpayment.py
+++ b/sendpayment.py
@@ -282,7 +282,9 @@ def main():
                       action='store',
                       type='int',
                       dest='makercount',
-                      help='how many makers to coinjoin with, default random from 4 to 6',
+                      help='how many makers to coinjoin with, default random '
+                           'from 4 to 6; use 0 to send *direct* to a destination '
+                           'address, not using Joinmarket',
                       default=random.randint(4, 6))
     parser.add_option(
         '-C',

--- a/sendpayment.py
+++ b/sendpayment.py
@@ -15,7 +15,7 @@ from joinmarket import Taker, load_program_config, IRCMessageChannel, \
 from joinmarket import validate_address, jm_single
 from joinmarket import get_log, choose_sweep_orders, choose_orders, \
     pick_order, cheapest_order_choose, weighted_order_choose, debug_dump_object
-from joinmarket import Wallet, BitcoinCoreWallet
+from joinmarket import Wallet, BitcoinCoreWallet, sync_wallet
 from joinmarket.wallet import estimate_tx_fee
 
 log = get_log()
@@ -276,6 +276,12 @@ def main():
         help=('Use the Bitcoin Core wallet through json rpc, instead '
               'of the internal joinmarket wallet. Requires '
               'blockchain_source=json-rpc'))
+    parser.add_option('--fast',
+                      action='store_true',
+                      dest='fastsync',
+                      default=False,
+                      help=('choose to do fast wallet sync, only for Core and '
+                      'only for previously synced wallet'))
     (options, args) = parser.parse_args()
 
     if len(args) < 3:
@@ -316,7 +322,7 @@ def main():
         wallet = Wallet(wallet_name, options.amtmixdepths, options.gaplimit)
     else:
         wallet = BitcoinCoreWallet(fromaccount=wallet_name)
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet, fast=options.fastsync)
 
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)

--- a/sendpayment.py
+++ b/sendpayment.py
@@ -334,7 +334,7 @@ def main():
         log.info('starting message channels')
         mcc.run()
     except:
-        log.warn('CRASHING, DUMPING EVERYTHING')
+        log.warn('Quitting! Dumping object contents to logfile.')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'wallet_name', 'seed'])
         debug_dump_object(taker)
         import traceback

--- a/test/regtest_joinmarket.cfg
+++ b/test/regtest_joinmarket.cfg
@@ -18,6 +18,8 @@ usessl = false, false
 socks5 = false, false
 socks5_host = localhost, localhost
 socks5_port = 9150, 9150
+[LOGGING]
+console_log_level = DEBUG
 [POLICY]
 # for dust sweeping, try merge_algorithm = gradual
 # for more rapid dust sweeping, try merge_algorithm = greedy
@@ -31,6 +33,7 @@ merge_algorithm = default
 # as our default. Note that for clients not using a local blockchain
 # instance, we retrieve an estimate from the API at cointape.com, currently.
 tx_fees = 3
+minimum_makers = 2
 taker_utxo_retries = 3
 taker_utxo_age = 1
 taker_utxo_amtpercent = 20

--- a/test/test_blockr.py
+++ b/test/test_blockr.py
@@ -11,7 +11,7 @@ import json
 
 import bitcoin as btc
 import pytest
-from joinmarket import load_program_config, jm_single
+from joinmarket import load_program_config, jm_single, sync_wallet
 from joinmarket.blockchaininterface import BlockrInterface
 from joinmarket import get_p2pk_vbyte, get_log, Wallet
 
@@ -62,7 +62,7 @@ def test_blockr_estimate_fee(setup_blockr):
 def test_blockr_sync(setup_blockr, net, seed, gaplimit, showprivkey, method):
     jm_single().config.set("BLOCKCHAIN", "network", net)
     wallet = Wallet(seed, max_mix_depth = 5)
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
 
     #copy pasted from wallet-tool; some boiled down form of
     #this should really be in wallet.py in the joinmarket module.

--- a/test/test_donations.py
+++ b/test/test_donations.py
@@ -10,7 +10,7 @@ import pytest
 
 from commontest import make_wallets
 from joinmarket import load_program_config, get_p2pk_vbyte, get_log, jm_single
-from joinmarket import get_irc_mchannels, Taker
+from joinmarket import get_irc_mchannels, Taker, sync_wallet
 from joinmarket.configure import donation_address
 
 log = get_log()
@@ -24,7 +24,7 @@ def test_donation_address(setup_donations, amount):
     wallets = make_wallets(1, wallet_structures=[[1,1,1,0,0]],
                                mean_amt=0.5)
     wallet = wallets[0]['wallet']
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     #make a rdp from a simple privkey
     rdp_priv = "\x01"*32
     reusable_donation_pubkey = binascii.hexlify(secp256k1.PrivateKey(

--- a/test/test_podle.py
+++ b/test/test_podle.py
@@ -17,7 +17,7 @@ from pprint import pformat
 from joinmarket import Taker, load_program_config, IRCMessageChannel
 from joinmarket import validate_address, jm_single, get_irc_mchannels
 from joinmarket import get_p2pk_vbyte, MessageChannelCollection
-from joinmarket import get_log, choose_sweep_orders, choose_orders, \
+from joinmarket import get_log, choose_sweep_orders, choose_orders, sync_wallet, \
     pick_order, cheapest_order_choose, weighted_order_choose, debug_dump_object
 import joinmarket.irc
 import sendpayment
@@ -145,7 +145,7 @@ def test_failed_sendpayment(setup_podle, num_ygs, wallet_structures, mean_amt,
 
     log.debug('starting sendpayment')
 
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     
     #Trigger PING LAG sending artificially
     joinmarket.irc.PING_INTERVAL = 3
@@ -241,7 +241,7 @@ def test_external_commitment_used(setup_podle):
 
     log.debug('starting sendpayment')
 
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     
     #Trigger PING LAG sending artificially
     joinmarket.irc.PING_INTERVAL = 3
@@ -347,7 +347,7 @@ def test_tx_commitments_used(setup_podle, consume_tx, age_required, cmt_age):
 
     log.debug('starting sendpayment')
 
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     log.debug("Here is the whole wallet: \n" + str(wallet.unspent))
     #Trigger PING LAG sending artificially
     joinmarket.irc.PING_INTERVAL = 3

--- a/test/test_podle.py
+++ b/test/test_podle.py
@@ -16,7 +16,7 @@ import time
 from pprint import pformat
 from joinmarket import Taker, load_program_config, IRCMessageChannel
 from joinmarket import validate_address, jm_single, get_irc_mchannels
-from joinmarket import random_nick, get_p2pk_vbyte, MessageChannelCollection
+from joinmarket import get_p2pk_vbyte, MessageChannelCollection
 from joinmarket import get_log, choose_sweep_orders, choose_orders, \
     pick_order, cheapest_order_choose, weighted_order_choose, debug_dump_object
 import joinmarket.irc

--- a/test/test_regtest.py
+++ b/test/test_regtest.py
@@ -12,7 +12,7 @@ import time
 from joinmarket import (Taker, load_program_config, IRCMessageChannel,
                         BitcoinCoreWallet)
 from joinmarket import validate_address, jm_single, get_irc_mchannels
-from joinmarket import random_nick, get_p2pk_vbyte, MessageChannelCollection
+from joinmarket import get_p2pk_vbyte, MessageChannelCollection
 from joinmarket import get_log, choose_sweep_orders, choose_orders, \
     pick_order, cheapest_order_choose, weighted_order_choose, debug_dump_object
 import joinmarket.irc

--- a/test/test_regtest.py
+++ b/test/test_regtest.py
@@ -10,7 +10,7 @@ import shutil
 import pytest
 import time
 from joinmarket import (Taker, load_program_config, IRCMessageChannel,
-                        BitcoinCoreWallet)
+                        BitcoinCoreWallet, sync_wallet)
 from joinmarket import validate_address, jm_single, get_irc_mchannels
 from joinmarket import get_p2pk_vbyte, MessageChannelCollection
 from joinmarket import get_log, choose_sweep_orders, choose_orders, \
@@ -102,7 +102,7 @@ def test_sendpayment(setup_regtest, num_ygs, wallet_structures, mean_amt,
 
     log.debug('starting sendpayment')
 
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     
     #Trigger PING LAG sending artificially
     joinmarket.irc.PING_INTERVAL = 3

--- a/test/test_regtest.py
+++ b/test/test_regtest.py
@@ -26,6 +26,49 @@ yg_cmd = 'yield-generator-basic.py'
 #yg_cmd = 'yg-pe.py'
 
 @pytest.mark.parametrize(
+    "wallet_structures, mean_amt, mixdepth, amount, valid",
+    [
+        # Normal send
+        ([[0, 3, 0, 0, 0]], 1, 1, 222000000, True),
+        # Sweep
+        ([[4, 1, 0, 0, 0]], 1, 0, 0, True),
+        # Too large amount
+        ([[4, 1, 0, 0, 0]], 1, 0, 40000000000, False),
+        # Invalid amount
+        ([[4, 1, 0, 0, 0]], 1, 0, -5000000, False),
+        # Invalid mixdepth
+        ([[4, 1, 0, 0, 0]], 1, -3, 5000000, False),
+        # Invalid amount type
+        ([[4, 1, 0, 0, 0]], 1, 0, "5000000", False),
+        # Invalid mixdepth type
+        ([[4, 1, 0, 0, 0]], 1, "p", 5000000, False),
+        # Spend from high mixdepth
+        ([[0,0,0,0,2]], 2, 4, 312000000, True),
+    ])
+def test_direct_send(setup_regtest, wallet_structures, mean_amt, mixdepth,
+                     amount, valid):
+    log = get_log()
+    wallets = make_wallets(1,
+                           wallet_structures=wallet_structures,
+                           mean_amt=mean_amt)
+    wallet = wallets[0]['wallet']
+    sync_wallet(wallet)
+    destaddr = btc.privkey_to_address(
+                os.urandom(32), #TODO deterministic-ise
+                from_hex=False,
+                magicbyte=get_p2pk_vbyte())
+    addr_valid, errormsg = validate_address(destaddr)
+    assert addr_valid, "Invalid destination address: " + destaddr + \
+               ", error message: " + errormsg
+    if not valid:
+        with pytest.raises(Exception) as e_info:
+            sendpayment.direct_send(wallet,
+                                    amount, mixdepth, destaddr, answeryes=True)
+    else:
+        sendpayment.direct_send(wallet,
+                                amount, mixdepth, destaddr, answeryes=True)
+
+@pytest.mark.parametrize(
     "num_ygs, wallet_structures, mean_amt, mixdepth, sending_amt, ygcfs, fails, donate, rpcwallet",
     [
         #Some tests are commented out to keep build test time reasonable.

--- a/test/test_tumbler.py
+++ b/test/test_tumbler.py
@@ -11,7 +11,7 @@ import time
 from joinmarket import Taker, load_program_config, IRCMessageChannel
 from joinmarket import validate_address, jm_single, MessageChannelCollection
 from joinmarket import get_p2pk_vbyte, get_irc_mchannels
-from joinmarket import get_log, choose_sweep_orders, choose_orders, \
+from joinmarket import get_log, choose_sweep_orders, choose_orders, sync_wallet, \
     pick_order, cheapest_order_choose, weighted_order_choose, debug_dump_object
 import json
 import tumbler
@@ -147,7 +147,7 @@ def test_tumbler(setup_tumbler, num_ygs, wallet_structures, mean_amt, sdev_amt,
 
     log.debug('starting tumbler')
 
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     jm_single().bc_interface.pushtx_failure_prob = 0.4
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)

--- a/test/test_tumbler.py
+++ b/test/test_tumbler.py
@@ -10,7 +10,7 @@ import pytest
 import time
 from joinmarket import Taker, load_program_config, IRCMessageChannel
 from joinmarket import validate_address, jm_single, MessageChannelCollection
-from joinmarket import random_nick, get_p2pk_vbyte, get_irc_mchannels
+from joinmarket import get_p2pk_vbyte, get_irc_mchannels
 from joinmarket import get_log, choose_sweep_orders, choose_orders, \
     pick_order, cheapest_order_choose, weighted_order_choose, debug_dump_object
 import json
@@ -145,13 +145,11 @@ def test_tumbler(setup_tumbler, num_ygs, wallet_structures, mean_amt, sdev_amt,
     print('estimated time taken ' + str(total_block_and_wait) + ' minutes or ' +
           str(round(total_block_and_wait / 60.0, 2)) + ' hours')
 
-    jm_single().nickname = random_nick()
-
     log.debug('starting tumbler')
 
     jm_single().bc_interface.sync_wallet(wallet)
     jm_single().bc_interface.pushtx_failure_prob = 0.4
-    mcs = [IRCMessageChannel(c, jm_single().nickname) for c in get_irc_mchannels()]
+    mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
     tumbler_bot = tumbler.Tumbler(mcc, wallet, tx_list, options)
     try:

--- a/test/test_tx_creation.py
+++ b/test/test_tx_creation.py
@@ -15,7 +15,7 @@ from commontest import local_command, interact, make_wallets, make_sign_and_push
 
 import bitcoin as btc
 import pytest
-from joinmarket import load_program_config, jm_single
+from joinmarket import load_program_config, jm_single, sync_wallet
 from joinmarket import get_p2pk_vbyte, get_log, Wallet
 from joinmarket.support import chunks, select_gradual, \
      select_greedy, select_greediest
@@ -41,7 +41,7 @@ def test_create_p2sh_output_tx(setup_tx_creation, nw, wallet_structures,
                                mean_amt, sdev_amt, amount, pubs, k):
     wallets = make_wallets(nw, wallet_structures, mean_amt, sdev_amt)
     for w in wallets.values():
-        jm_single().bc_interface.sync_wallet(w['wallet'])
+        sync_wallet(w['wallet'])
     for k, w in enumerate(wallets.values()):
         wallet = w['wallet']
         ins_full = wallet.select_utxos(0, amount)
@@ -65,7 +65,7 @@ def test_absurd_fees(setup_tx_creation):
     jm_single().bc_interface.absurd_fees = True
     #pay into it
     wallet = make_wallets(1, [[2, 0, 0, 0, 1]], 3)[0]['wallet']
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     amount = 350000000
     ins_full = wallet.select_utxos(0, amount)
     with pytest.raises(ValueError) as e_info:
@@ -76,7 +76,7 @@ def test_create_sighash_txs(setup_tx_creation):
     for sighash in [btc.SIGHASH_ANYONECANPAY + btc.SIGHASH_SINGLE,
                     btc.SIGHASH_NONE, btc.SIGHASH_SINGLE]:
         wallet = make_wallets(1, [[2, 0, 0, 0, 1]], 3)[0]['wallet']
-        jm_single().bc_interface.sync_wallet(wallet)
+        sync_wallet(wallet)
         amount = 350000000
         ins_full = wallet.select_utxos(0, amount)
         print "using hashcode: " + str(sighash)
@@ -105,7 +105,7 @@ def test_spend_p2sh_utxos(setup_tx_creation):
     msig_addr = btc.scriptaddr(script, magicbyte=196)
     #pay into it
     wallet = make_wallets(1, [[2, 0, 0, 0, 1]], 3)[0]['wallet']
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     amount = 350000000
     ins_full = wallet.select_utxos(0, amount)
     txid = make_sign_and_push(ins_full, wallet, amount, output_addr=msig_addr)

--- a/test/test_tx_notify.py
+++ b/test/test_tx_notify.py
@@ -9,7 +9,7 @@ from commontest import make_wallets
 import bitcoin as btc
 import pytest
 from joinmarket import load_program_config, jm_single
-from joinmarket import get_log, Wallet
+from joinmarket import get_log, Wallet, sync_wallet
 
 log = get_log()
 
@@ -71,7 +71,7 @@ def make_tx_add_notify():
     amount = 250000000
     txfee = 10000
     wallet = wallet_dict['wallet']
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     inputs = wallet.select_utxos(0, amount)
     ins = inputs.keys()
     input_value = sum([i['value'] for i in inputs.values()])

--- a/test/test_wallets.py
+++ b/test/test_wallets.py
@@ -12,10 +12,11 @@ import subprocess
 import unittest
 from decimal import Decimal
 from commontest import local_command, interact, make_wallets, make_sign_and_push
+import json
 
 import bitcoin as btc
 import pytest
-from joinmarket import load_program_config, jm_single
+from joinmarket import load_program_config, jm_single, sync_wallet
 from joinmarket import get_p2pk_vbyte, get_log, Wallet
 from joinmarket.support import chunks, select_gradual, \
      select_greedy, select_greediest
@@ -36,42 +37,6 @@ def do_tx(wallet, amount):
     time.sleep(2) #blocks
     jm_single().bc_interface.sync_unspent(wallet)
 
-"""
-@pytest.mark.parametrize(
-    "num_txs, gap_count, gap_limit, wallet_structure, amount, wallet_file, password",
-    [
-        (3, 450, 461, [11,3,4,5,6], 150000000, 'test_import_wallet.json', 'import-pwd'
-         ),
-    ])
-def test_wallet_gap_sync(setup_wallets, num_txs, gap_count, gap_limit,
-                     wallet_structure, amount, wallet_file, password):
-    #Starting with a nonexistent index_cache, try syncing with a large
-    #gap limit
-    setup_import(mainnet=False)
-    wallet = make_wallets(1,[wallet_structure],
-                          fixed_seeds=[wallet_file],
-                          test_wallet=True, passwords=[password])[0]['wallet']
-    wallet.gaplimit = gap_limit
-    #Artificially insert coins at position (0, wallet_structures[0] + gap_count)
-    dest = wallet.get_addr(0, 0, wallet_structure[0] + gap_count)
-    btcamt = amount/(1e8)
-    jm_single().bc_interface.grab_coins(dest, amt=float(Decimal(btcamt).quantize(Decimal(10)**-8)))
-    time.sleep(2)
-    sync_count = 0
-    jm_single().bc_interface.wallet_synced = False
-    while not jm_single().bc_interface.wallet_synced:
-        wallet.index = []
-        for i in range(5):
-            wallet.index.append([0, 0])
-        jm_single().bc_interface.sync_wallet(wallet)
-        sync_count += 1
-        #avoid infinite loop
-        assert sync_count < 10
-        log.debug("Tried " + str(sync_count) + " times")
-
-    assert jm_single().bc_interface.wallet_synced
-"""
-
 @pytest.mark.parametrize(
     "num_txs, fake_count, wallet_structure, amount, wallet_file, password",
     [
@@ -90,7 +55,7 @@ def test_wallet_gap_sync(setup_wallets, num_txs, gap_count, gap_limit,
         #(25, 30, [30,20,1,1,1], 50000000, 'test_import_wallet.json', 'import-pwd'
         # ),
     ])
-def test_wallet_sync(setup_wallets, num_txs, fake_count,
+def test_wallet_sync_with_fast(setup_wallets, num_txs, fake_count,
                      wallet_structure, amount, wallet_file, password):
     setup_import(mainnet=False)
     wallet = make_wallets(1,[wallet_structure],
@@ -99,13 +64,14 @@ def test_wallet_sync(setup_wallets, num_txs, fake_count,
     sync_count = 0
     jm_single().bc_interface.wallet_synced = False
     while not jm_single().bc_interface.wallet_synced:
-        jm_single().bc_interface.sync_wallet(wallet)
+        sync_wallet(wallet)
         sync_count += 1
         #avoid infinite loop
         assert sync_count < 10
         log.debug("Tried " + str(sync_count) + " times")
 
     assert jm_single().bc_interface.wallet_synced
+    assert not jm_single().bc_interface.fast_sync_called
     #do some transactions with the wallet, then close, then resync
     for i in range(num_txs):
         do_tx(wallet, amount)
@@ -152,13 +118,13 @@ def test_wallet_sync(setup_wallets, num_txs, fake_count,
         #script over and over again)?
         sync_count += 1
         log.debug("TRYING SYNC NUMBER: " + str(sync_count))
-        jm_single().bc_interface.sync_wallet(wallet)
+        sync_wallet(wallet, fast=True)
+        assert jm_single().bc_interface.fast_sync_called
         #avoid infinite loop on failure.
         assert sync_count < 10
-    #Wallet should recognize index_cache on sync, so should not need to
-    #run sync process more than twice (twice if cache bump has moved us
-    #past the first round of imports).
-    assert sync_count <= 2
+    #Wallet should recognize index_cache on fast sync, so should not need to
+    #run sync process more than once.
+    assert sync_count == 1
     #validate the wallet index values after sync
     for i, ws in enumerate(wallet_structure):
         assert wallet.index[i][0] == ws #spends into external only
@@ -181,7 +147,7 @@ def test_wallet_sync(setup_wallets, num_txs, fake_count,
         # [(12,3),(100,99),(7, 40), (200, 201), (10,0)]
         # ),
         ([1,3,0,2,9], 'test_import_wallet.json', 'import-pwd',
-         [(0,7),(100,99),(0, 0), (200, 201), (21,41)]
+         [(1,7),(100,99),(0, 0), (200, 201), (21,41)]
          ),
     ])
 def test_wallet_sync_from_scratch(setup_wallets, wallet_structure,
@@ -202,13 +168,14 @@ def test_wallet_sync_from_scratch(setup_wallets, wallet_structure,
         wallet.index = []
         for i in range(5):
             wallet.index.append([0, 0])
-        jm_single().bc_interface.sync_wallet(wallet)
+        #will call with fast=False but index_cache exists; should use slow-sync
+        sync_wallet(wallet)
         sync_count += 1
         #avoid infinite loop
         assert sync_count < 10
         log.debug("Tried " + str(sync_count) + " times")
     #after #586 we expect to ALWAYS succeed within 2 rounds
-    assert sync_count == 2
+    assert sync_count <= 2
     #for each external branch, the new index may be higher than
     #the original index_cache if there was a higher used address
     expected_wallet_index = []
@@ -219,6 +186,8 @@ def test_wallet_sync_from_scratch(setup_wallets, wallet_structure,
             expected_wallet_index.append([wallet.index_cache[i][0],
                                           wallet.index_cache[i][1]])
     assert wallet.index == expected_wallet_index
+    log.debug("This is wallet unspent: ")
+    log.debug(json.dumps(wallet.unspent, indent=4))
 
 
 @pytest.mark.parametrize(
@@ -287,7 +256,7 @@ def test_utxo_selection(setup_wallets, nw, wallet_structures, mean_amt,
     wallets = make_wallets(nw, wallet_structures, mean_amt, sdev_amt)
     for w in wallets.values():
         jm_single().bc_interface.wallet_synced = False
-        jm_single().bc_interface.sync_wallet(w['wallet'])
+        sync_wallet(w['wallet'])
     for k, w in enumerate(wallets.values()):
         for algo in [select_gradual, select_greedy, select_greediest, None]:
             wallet = w['wallet']

--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -20,7 +20,7 @@ import os
 import pytest
 import sys
 import time
-from joinmarket import load_program_config, jm_single
+from joinmarket import load_program_config, jm_single, sync_wallet
 
 #for running bots as subprocesses
 python_cmd = 'python2'
@@ -46,7 +46,7 @@ def test_start_ygs(setup_ygrunner, num_ygs, wallet_structures, mean_amt):
     wallet = wallets[num_ygs]['wallet']
     print "Seed : " + wallets[num_ygs]['seed']
     #useful to see the utxos on screen sometimes
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet)
     print wallet.unspent
 
     yigen_procs = []

--- a/tumbler.py
+++ b/tumbler.py
@@ -637,7 +637,7 @@ def main():
     # python tumbler.py -N 2 1 -c 3 0.001 -l 0.1 -M 3 -a 0 wallet_file 1xxx 1yyy
     wallet = Wallet(wallet_file,
                     max_mix_depth=options['mixdepthsrc'] + options['mixdepthcount'])
-    sync_wallet(wallet, fast=options.fastsync)
+    sync_wallet(wallet, fast=options['fastsync'])
     jm_single().wait_for_commitments = 1
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
@@ -647,7 +647,7 @@ def main():
         log.info('connecting to message channels')
         mcc.run()
     except:
-        log.warn('CRASHING, DUMPING EVERYTHING')
+        log.warn('Quitting! Dumping object contents to logfile.')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
         debug_dump_object(tumbler)
         debug_dump_object(tumbler.cjtx)

--- a/tumbler.py
+++ b/tumbler.py
@@ -14,7 +14,6 @@ from pprint import pprint
 from joinmarket import jm_single, Taker, load_program_config, \
     IRCMessageChannel, MessageChannelCollection
 from joinmarket import validate_address
-from joinmarket import random_nick
 from joinmarket import get_log, rand_norm_array, rand_pow_array, \
     rand_exp_array, choose_orders, weighted_order_choose, choose_sweep_orders, \
     debug_dump_object, get_irc_mchannels

--- a/tumbler.py
+++ b/tumbler.py
@@ -13,7 +13,7 @@ from pprint import pprint
 
 from joinmarket import jm_single, Taker, load_program_config, \
     IRCMessageChannel, MessageChannelCollection
-from joinmarket import validate_address
+from joinmarket import validate_address, sync_wallet
 from joinmarket import get_log, rand_norm_array, rand_pow_array, \
     rand_exp_array, choose_orders, weighted_order_choose, choose_sweep_orders, \
     debug_dump_object, get_irc_mchannels
@@ -545,6 +545,12 @@ def main():
             default=9,
             help=
             'maximum amount of times to re-create a transaction before giving up, default 9')
+    parser.add_option('--fast',
+                      action='store_true',
+                      dest='fastsync',
+                      default=False,
+                      help=('choose to do fast wallet sync, only for Core and '
+                      'only for previously synced wallet'))
     (options, args) = parser.parse_args()
     options = vars(options)
 
@@ -631,7 +637,7 @@ def main():
     # python tumbler.py -N 2 1 -c 3 0.001 -l 0.1 -M 3 -a 0 wallet_file 1xxx 1yyy
     wallet = Wallet(wallet_file,
                     max_mix_depth=options['mixdepthsrc'] + options['mixdepthcount'])
-    jm_single().bc_interface.sync_wallet(wallet)
+    sync_wallet(wallet, fast=options.fastsync)
     jm_single().wait_for_commitments = 1
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)

--- a/tumbler.py
+++ b/tumbler.py
@@ -109,7 +109,7 @@ class TumblerThread(threading.Thread):
         self.create_tx_attempts = 0
 
     def unconfirm_callback(self, txd, txid):
-        log.debug('that was %d tx out of %d, waiting for confirmation' %
+        log.info('that was %d tx out of %d, waiting for confirmation' %
                   (self.current_tx + 1, len(self.taker.tx_list)))
 
     def confirm_callback(self, txd, txid, confirmations):
@@ -122,19 +122,19 @@ class TumblerThread(threading.Thread):
         if not confirmed:
             #try rebroadcasting a few times, then create again
             if self.broadcast_attempts == 0:
-                log.debug('timed out for unconfirmed tx, recreating')
+                log.info('timed out for unconfirmed tx, recreating')
                 self.create_tx()
                 #need a countdown here and other places, maybe inside
                 #create_tx in case theres some long-running problem
                 return
             self.broadcast_attempts -= 1
-            log.debug('timed out for unconfirmed tx, rebroadcasting')
+            log.info('timed out for unconfirmed tx, rebroadcasting')
             pushed = self.pushtx()
             if not pushed:
-                log.debug("Failed to push transaction, recreating")
+                log.info("Failed to push transaction, recreating")
                 self.create_tx()
         else:
-            log.debug('timed out waiting for confirmation')
+            log.info('timed out waiting for confirmation')
 
     def pushtx(self):
         push_attempts = 3
@@ -159,11 +159,11 @@ class TumblerThread(threading.Thread):
             coinjointx.self_sign()
             pushed = self.pushtx()
             if not pushed:
-                log.debug("Failed to push transaction, recreating")
+                log.info("Failed to push transaction, recreating")
                 self.create_tx()
         else:
             self.ignored_makers += coinjointx.nonrespondants
-            log.debug('recreating the tx, ignored_makers=' + str(
+            log.info('recreating the tx, ignored_makers=' + str(
                     self.ignored_makers))
             self.create_tx_attempts += 1 #nonrespondants dont count for timeout
             self.create_tx()
@@ -184,29 +184,29 @@ class TumblerThread(threading.Thread):
                     self.ignored_makers + active_nicks)
             abs_cj_fee = 1.0 * total_cj_fee / makercount
             rel_cj_fee = abs_cj_fee / cj_amount
-            log.debug('rel/abs average fee = ' + str(rel_cj_fee) + ' / ' + str(
+            log.info('rel/abs average fee = ' + str(rel_cj_fee) + ' / ' + str(
                     abs_cj_fee))
 
             if rel_cj_fee > self.taker.options['maxcjfee'][
                 0] and abs_cj_fee > self.taker.options['maxcjfee'][1]:
-                log.debug('cj fee higher than maxcjfee, waiting ' + str(
+                log.warn('cj fee higher than maxcjfee, waiting ' + str(
                         self.taker.options['liquiditywait']) + ' seconds')
                 time.sleep(self.taker.options['liquiditywait'])
                 continue
             if orders is None:
-                log.debug('waiting for liquidity ' + str(
+                log.warn('waiting for liquidity ' + str(
                         self.taker.options['liquiditywait']) +
                           'secs, hopefully more orders should come in')
                 time.sleep(self.taker.options['liquiditywait'])
                 continue
             break
-        log.debug('chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(
+        log.info('chosen orders to fill ' + str(orders) + ' totalcjfee=' + str(
                 total_cj_fee))
         return orders, total_cj_fee
 
     def create_tx(self):
         if self.create_tx_attempts == 0:
-             log.debug('reached limit of number of attempts to create tx, quitting')
+             log.error('reached limit of number of attempts to create tx, quitting')
              self.taker.msgchan.shutdown()
              return
         jm_single().bc_interface.sync_unspent(self.taker.wallet)
@@ -216,7 +216,7 @@ class TumblerThread(threading.Thread):
         change_addr = None
         choose_orders_recover = None
         if self.sweep:
-            log.debug('sweeping')
+            log.info('sweeping')
             utxos = self.taker.wallet.get_utxos_by_mixdepth()[self.tx[
                 'srcmixdepth']]
             #do our best to estimate the fee based on the number of
@@ -229,8 +229,8 @@ class TumblerThread(threading.Thread):
             est_outs = 2*self.tx['makercount'] + 1
             log.debug("Estimated outs: "+str(est_outs))
             estimated_fee = estimate_tx_fee(est_ins, est_outs)
-            log.debug("We have a fee estimate: "+str(estimated_fee))
-            log.debug("And a requested fee of: "+str(
+            log.info("We have a fee estimate: "+str(estimated_fee))
+            log.info("And a requested fee of: "+str(
                 self.taker.options['txfee'] * self.tx['makercount']))
             fee_for_tx = max([estimated_fee,
                               self.tx['makercount'] * self.taker.options['txfee']])
@@ -242,19 +242,19 @@ class TumblerThread(threading.Thread):
                         self.tx['makercount'], weighted_order_choose,
                         self.ignored_makers)
                 if orders is None:
-                    log.debug('waiting for liquidity ' + str(
+                    log.warn('waiting for liquidity ' + str(
                             self.taker.options['liquiditywait']) +
                               'secs, hopefully more orders should come in')
                     time.sleep(self.taker.options['liquiditywait'])
                     continue
                 abs_cj_fee = 1.0 * total_cj_fee / self.tx['makercount']
                 rel_cj_fee = abs_cj_fee / cj_amount
-                log.debug(
+                log.info(
                     'rel/abs average fee = ' + str(rel_cj_fee) + ' / ' + str(
                             abs_cj_fee))
                 if rel_cj_fee > self.taker.options['maxcjfee'][0] \
                         and abs_cj_fee > self.taker.options['maxcjfee'][1]:
-                    log.debug('cj fee higher than maxcjfee, waiting ' + str(
+                    log.warn('cj fee higher than maxcjfee, waiting ' + str(
                             self.taker.options['liquiditywait']) + ' seconds')
                     time.sleep(self.taker.options['liquiditywait'])
                     continue
@@ -267,16 +267,16 @@ class TumblerThread(threading.Thread):
             else:
                 cj_amount = int(self.tx['amount_fraction'] * self.balance)
             if cj_amount < self.taker.options['mincjamount']:
-                log.debug('cj amount too low, bringing up')
+                log.info('cj amount too low, bringing up')
                 cj_amount = self.taker.options['mincjamount']
             change_addr = self.taker.wallet.get_internal_addr(
                 self.tx['srcmixdepth'])
-            log.debug('coinjoining ' + str(cj_amount) + ' satoshi')
+            log.info('coinjoining ' + str(cj_amount) + ' satoshi')
             orders, total_cj_fee = self.tumbler_choose_orders(
                     cj_amount, self.tx['makercount'])
             total_amount = cj_amount + total_cj_fee + \
                 self.taker.options['txfee']*self.tx['makercount']
-            log.debug('total estimated amount spent = ' + str(total_amount))
+            log.info('total estimated amount spent = ' + str(total_amount))
             #adjust the required amount upwards to anticipate an increase of the
             #transaction fee after re-estimation; this is sufficiently conservative
             #to make failures unlikely while keeping the occurence of failure to
@@ -290,7 +290,7 @@ class TumblerThread(threading.Thread):
                 #try with a smaller request; it could still fail within
                 #CoinJoinTX.recv_txio, but make every effort to avoid stopping.
                 if str(e) == "Not enough funds":
-                    log.debug("Failed to select total amount + twice txfee from" +
+                    log.warn("Failed to select total amount + twice txfee from" +
                           "wallet; trying to select just total amount.")
                     utxos = self.taker.wallet.select_utxos(self.tx['srcmixdepth'],
                             total_amount)
@@ -334,12 +334,12 @@ class TumblerThread(threading.Thread):
         self.create_tx()
         with self.lockcond:
             self.lockcond.wait()
-        log.debug('tx confirmed, waiting for ' + str(tx['wait']) + ' minutes')
+        log.info('tx confirmed, waiting for ' + str(tx['wait']) + ' minutes')
         time.sleep(tx['wait'] * 60)
-        log.debug('woken')
+        log.info('woken')
 
     def run(self):
-        log.debug('waiting for all orders to certainly arrive')
+        log.info('waiting for all orders to certainly arrive')
         time.sleep(self.taker.options['waittime'])
 
         sqlorders = self.taker.db.execute(
@@ -347,16 +347,16 @@ class TumblerThread(threading.Thread):
         orders = [o['cjfee'] for o in sqlorders if o['ordertype'] == 'reloffer']
         orders = sorted(orders)
         if len(orders) == 0:
-            log.debug('There are no orders at all in the orderbook! '
+            log.error('There are no orders at all in the orderbook! '
                       'Is the bot connecting to the right server?')
             return
         relorder_fee = float(orders[0])
-        log.debug('reloffer fee = ' + str(relorder_fee))
+        log.info('reloffer fee = ' + str(relorder_fee))
         maker_count = sum([tx['makercount'] for tx in self.taker.tx_list])
-        log.debug('uses ' + str(maker_count) + ' makers, at ' + str(
+        log.info('uses ' + str(maker_count) + ' makers, at ' + str(
                 relorder_fee * 100) + '% per maker, estimated total cost ' + str(
                 round((1 - (1 - relorder_fee) ** maker_count) * 100, 3)) + '%')
-        log.debug('starting')
+        log.info('starting')
         self.lockcond = threading.Condition()
 
         self.balance_by_mixdepth = {}
@@ -372,7 +372,7 @@ class TumblerThread(threading.Thread):
             self.current_tx = i
             self.init_tx(tx, self.balance_by_mixdepth[tx['srcmixdepth']], sweep)
 
-        log.debug('total finished')
+        log.info('total finished')
         self.taker.msgchan.shutdown()
 
 class Tumbler(Taker):
@@ -573,7 +573,7 @@ def main():
     # we guess conservatively with 2 inputs and 2 outputs each
     if options['txfee'] == -1:
         options['txfee'] = max(options['txfee'], estimate_tx_fee(2, 2))
-        log.debug("Estimated miner/tx fee for each cj participant: "+str(options['txfee']))
+        log.info("Estimated miner/tx fee for each cj participant: "+str(options['txfee']))
     assert(options['txfee'] >= 0)
 
     if len(destaddrs) > options['addrcount']:
@@ -602,7 +602,7 @@ def main():
     dbg_tx_list = []
     for srcmixdepth, txlist in tx_dict.iteritems():
         dbg_tx_list.append({'srcmixdepth': srcmixdepth, 'tx': txlist})
-    log.debug('tumbler transaction list')
+    log.info('tumbler transaction list')
     pprint(dbg_tx_list)
 
     total_wait = sum([tx['wait'] for tx in tx_list])
@@ -641,13 +641,13 @@ def main():
     jm_single().wait_for_commitments = 1
     mcs = [IRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)
-    log.debug('starting tumbler')
+    log.info('starting tumbler')
     tumbler = Tumbler(mcc, wallet, tx_list, options)
     try:
-        log.debug('connecting to message channels')
+        log.info('connecting to message channels')
         mcc.run()
     except:
-        log.debug('CRASHING, DUMPING EVERYTHING')
+        log.warn('CRASHING, DUMPING EVERYTHING')
         debug_dump_object(wallet, ['addr_cache', 'keys', 'seed'])
         debug_dump_object(tumbler)
         debug_dump_object(tumbler.cjtx)

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -10,7 +10,7 @@ from optparse import OptionParser
 
 from joinmarket import load_program_config, get_network, Wallet, encryptData, \
     get_p2pk_vbyte, jm_single, mn_decode, mn_encode, BitcoinCoreInterface, \
-    JsonRpcError
+    JsonRpcError, sync_wallet
 
 import bitcoin as btc
 
@@ -63,6 +63,12 @@ parser.add_option('--csv',
                   dest='csv',
                   default=False,
                   help=('When using the history method, output as csv'))
+parser.add_option('--fast',
+                  action='store_true',
+                  dest='fastsync',
+                  default=False,
+                  help=('choose to do fast wallet sync, only for Core and '
+                  'only for previously synced wallet'))
 (options, args) = parser.parse_args()
 
 # if the index_cache stored in wallet.json is longer than the default
@@ -104,7 +110,8 @@ else:
         # unconfirmed balance is included in the wallet display by default
         if 'listunspent_args' not in jm_single().config.options('POLICY'):
             jm_single().config.set('POLICY','listunspent_args', '[0]')
-        jm_single().bc_interface.sync_wallet(wallet)
+
+        sync_wallet(wallet, fast=options.fastsync)
 
 if method == 'showutxos':
     unsp = {}

--- a/yg-pe.py
+++ b/yg-pe.py
@@ -2,13 +2,10 @@
 from __future__ import print_function
 
 import datetime
-import os
 import time
 
-from joinmarket import jm_single, get_network, load_program_config
-from joinmarket import get_log, calc_cj_fee, debug_dump_object
-from joinmarket import Wallet
-from joinmarket import get_irc_mchannels
+from joinmarket import jm_single
+from joinmarket import get_log, calc_cj_fee
 from joinmarket import YieldGenerator, ygmain
 
 txfee = 1000
@@ -27,24 +24,26 @@ log = get_log()
 # bitcoins while maximising the difficulty of spying on activity;
 # this is primarily attempted by avoiding reannouncemnt of orders
 # after transactions whereever that is possible.
-class YieldGeneratorPrivEnhance(YieldGenerator):
 
+
+class YieldGeneratorPrivEnhance(YieldGenerator):
 
     def __init__(self, msgchan, wallet, offerconfig):
         self.txfee, self.cjfee_a, self.cjfee_r, self.ordertype, self.minsize, \
             self.mix_levels = offerconfig
-        super(YieldGeneratorPrivEnhance,self).__init__(msgchan, wallet)
+        super(YieldGeneratorPrivEnhance, self).__init__(msgchan, wallet)
 
     def create_my_orders(self):
         mix_balance = self.wallet.get_balance_by_mixdepth()
-        #We publish ONLY the maximum amount and use minsize for lower bound;
-        #leave it to oid_to_order to figure out the right depth to use.
+        # We publish ONLY the maximum amount and use minsize for lower bound;
+        # leave it to oid_to_order to figure out the right depth to use.
         f = '0'
         if ordertype == 'reloffer':
             f = self.cjfee_r
-            #minimum size bumped if necessary such that you always profit 
-            #least 50% of the miner fee
-            self.minsize = max(int(1.5 * self.txfee / float(self.cjfee_r)), self.minsize)
+            # minimum size bumped if necessary such that you always profit
+            # least 50% of the miner fee
+            self.minsize = max(
+                int(1.5 * self.txfee / float(self.cjfee_r)), self.minsize)
         elif ordertype == 'absoffer':
             f = str(self.txfee + self.cjfee_a)
         mix_balance = dict([(m, b) for m, b in mix_balance.iteritems()
@@ -87,21 +86,22 @@ class YieldGeneratorPrivEnhance(YieldGenerator):
 
         log.debug('mix depths that have enough = ' + str(filtered_mix_balance))
 
-        #Avoid the max mixdepth wherever possible, to avoid changing the
-        #offer. Algo: 
+        # Avoid the max mixdepth wherever possible, to avoid changing the
+        # offer. Algo:
         #"mixdepth" is the mixdepth we are spending FROM, so it is also
-        #the destination of change.
+        # the destination of change.
         #"cjoutdepth" is the mixdepth we are sending coinjoin out to.
         #
-        #Find a mixdepth, in the set that have enough, which is
-        #not the maximum, and choose any from that set as "mixdepth".
-        #If not possible, it means only the max_mix depth has enough,
-        #so must choose "mixdepth" to be that.
-        #To find the cjoutdepth: ensure that max != min, if so it means
-        #we had only one depth; in that case, just set "cjoutdepth"
-        #to the next mixdepth. Otherwise, we set "cjoutdepth" to the minimum.
+        # Find a mixdepth, in the set that have enough, which is
+        # not the maximum, and choose any from that set as "mixdepth".
+        # If not possible, it means only the max_mix depth has enough,
+        # so must choose "mixdepth" to be that.
+        # To find the cjoutdepth: ensure that max != min, if so it means
+        # we had only one depth; in that case, just set "cjoutdepth"
+        # to the next mixdepth. Otherwise, we set "cjoutdepth" to the minimum.
 
-        nonmax_mix_balance = [m for m in filtered_mix_balance if m[0] != max_mix]
+        nonmax_mix_balance = [
+            m for m in filtered_mix_balance if m[0] != max_mix]
         if not nonmax_mix_balance:
             log.debug("Could not spend from a mixdepth which is not max")
             mixdepth = max_mix
@@ -111,10 +111,11 @@ class YieldGeneratorPrivEnhance(YieldGenerator):
 
         # mixdepth is the chosen depth we'll be spending from
         # min_mixdepth is the one we want to send our cjout TO,
-        # to minimize chance of it becoming the largest, and reannouncing offer.
+        # to minimize chance of it becoming the largest, and reannouncing
+        # offer.
         if mixdepth == min_mix:
             cjoutmix = (mixdepth + 1) % self.wallet.max_mix_depth
-            #don't send cjout to max
+            # don't send cjout to max
             if cjoutmix == max_mix:
                 cjoutmix = (cjoutmix + 1) % self.wallet.max_mix_depth
         else:

--- a/yg-pe.py
+++ b/yg-pe.py
@@ -49,7 +49,8 @@ class YieldGeneratorPrivEnhance(YieldGenerator):
         mix_balance = dict([(m, b) for m, b in mix_balance.iteritems()
                             if b > self.minsize])
         if len(mix_balance) == 0:
-            log.debug('do not have any coins left')
+            log.error('You do not have any coins left. Cannot be an active '
+                      'maker with no funds.')
             return []
         max_mix = max(mix_balance, key=mix_balance.get)
         order = {'oid': 0,
@@ -107,7 +108,7 @@ class YieldGeneratorPrivEnhance(YieldGenerator):
             mixdepth = max_mix
         else:
             mixdepth = nonmax_mix_balance[0][0]
-        log.debug('filling offer, mixdepth=' + str(mixdepth))
+        log.info('filling offer, mixdepth=' + str(mixdepth))
 
         # mixdepth is the chosen depth we'll be spending from
         # min_mixdepth is the one we want to send our cjout TO,
@@ -134,8 +135,9 @@ class YieldGeneratorPrivEnhance(YieldGenerator):
                 utxos = self.wallet.select_utxos(
                     mixdepth, total_amount + jm_single().DUST_THRESHOLD)
             except Exception:
-                log.debug('dont have the required UTXOs to make a '
-                          'output above the dust threshold, quitting')
+                log.info('dont have the required UTXOs to make a '
+                          'output above the dust threshold, quitting. '
+                          'This can sometimes happen and does not require user action.')
                 return None, None, None
 
         return utxos, cj_addr, change_addr

--- a/yg-pe.py
+++ b/yg-pe.py
@@ -18,6 +18,7 @@ ordertype = 'reloffer'
 nickserv_password = ''
 minsize = 100000
 mix_levels = 5
+gaplimit = 6
 
 
 log = get_log()
@@ -173,5 +174,5 @@ if __name__ == "__main__":
     ygmain(YieldGeneratorPrivEnhance, txfee=txfee,
            cjfee_a=cjfee_a, cjfee_r=cjfee_r,
            ordertype=ordertype, nickserv_password=nickserv_password,
-           minsize=minsize, mix_levels=mix_levels)
+           minsize=minsize, mix_levels=mix_levels, gaplimit=gaplimit)
     print('done')

--- a/yg-pe.py
+++ b/yg-pe.py
@@ -44,7 +44,7 @@ class YieldGeneratorPrivEnhance(YieldGenerator):
             f = self.cjfee_r
             #minimum size bumped if necessary such that you always profit 
             #least 50% of the miner fee
-            self.minsize = int(1.5 * self.txfee / float(self.cjfee_r))            
+            self.minsize = max(int(1.5 * self.txfee / float(self.cjfee_r)), self.minsize)
         elif ordertype == 'absoffer':
             f = str(self.txfee + self.cjfee_a)
         mix_balance = dict([(m, b) for m, b in mix_balance.iteritems()

--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -18,6 +18,7 @@ ordertype = 'reloffer'
 nickserv_password = ''
 minsize = 100000
 mix_levels = 5
+gaplimit = 6
 
 log = get_log()
 
@@ -133,5 +134,5 @@ if __name__ == "__main__":
     ygmain(YieldGeneratorBasic, txfee=txfee, cjfee_a=cjfee_a,
            cjfee_r=cjfee_r, ordertype=ordertype,
            nickserv_password=nickserv_password,
-           minsize=minsize, mix_levels=mix_levels)
+           minsize=minsize, mix_levels=mix_levels, gaplimit=gaplimit)
     print('done')

--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -37,7 +37,7 @@ class YieldGeneratorBasic(YieldGenerator):
     def create_my_orders(self):
         mix_balance = self.wallet.get_balance_by_mixdepth()
         if len([b for m, b in mix_balance.iteritems() if b > 0]) == 0:
-            log.debug('do not have any coins left')
+            log.error('do not have any coins left')
             return []
 
         # print mix_balance
@@ -78,7 +78,7 @@ class YieldGeneratorBasic(YieldGenerator):
         log.debug('mix depths that have enough = ' + str(filtered_mix_balance))
         filtered_mix_balance = sorted(filtered_mix_balance, key=lambda x: x[0])
         mixdepth = filtered_mix_balance[0][0]
-        log.debug('filling offer, mixdepth=' + str(mixdepth))
+        log.info('filling offer, mixdepth=' + str(mixdepth))
 
         # mixdepth is the chosen depth we'll be spending from
         cj_addr = self.wallet.get_internal_addr((mixdepth + 1) %
@@ -96,7 +96,7 @@ class YieldGeneratorBasic(YieldGenerator):
                 utxos = self.wallet.select_utxos(
                     mixdepth, total_amount + jm_single().DUST_THRESHOLD)
             except Exception:
-                log.debug('dont have the required UTXOs to make a '
+                log.info('dont have the required UTXOs to make a '
                           'output above the dust threshold, quitting')
                 return None, None, None
 

--- a/yield-generator-basic.py
+++ b/yield-generator-basic.py
@@ -47,7 +47,7 @@ class YieldGeneratorBasic(YieldGenerator):
             f = self.cjfee_r
             #minimum size bumped if necessary such that you always profit
             #least 50% of the miner fee
-            self.minsize = int(1.5 * self.txfee / float(self.cjfee_r))
+            self.minsize = max(int(1.5 * self.txfee / float(self.cjfee_r)), self.minsize)
         elif ordertype == 'absoffer':
             f = str(self.txfee + self.cjfee_a)
         order = {'oid': 0,


### PR DESCRIPTION
It occurred to me that this is a much simpler, faster, and possibly more robust way of dealing with unresponsive makers who don't even provide utxos or signature up to !ioauth.

This is not really intended to supercede the idea of more intelligent selection, something like outlined [here](https://gist.github.com/AdamISZ/79457f1c20bc0702d299d873c899676a) but is a more basic idea that is simpler.
 
If the number of full respondants in the `!fill` - `!ioauth` phase is less than that specified (by -N or similar), but is at least equal to `jm_single().config.getint("POLICY", "minimum_makers")`, then continue anyway - the change will be calculated correctly, higher than originally anticipated, and the txfee will be less than originally anticipated but it is already re-calculated at this point.

The timeout code in `recover_from_nonrespondants` thus checks the above arithmetic, if sufficient, it calls `recv_txio` with dummy values, which flags the code to skip the first step and pass straight into calculation of our change output and construction of `!tx` messages (nothing for the makers changes; their outputs are already set by their own fees).

Nothing changes for sweep; there was previously no way to handle any change in the input set of orders, and there still isn't (at least I haven't thought of one yet).

I've done various tests with randomly malicious makers (using `test/ygrunner.py` and inserted random failure-to-ioauth into `maker.py`) and it seems to work as intended.

User can flag not to use this feature by setting `POLICY.minimum_makers` to 0.

Review greatly welcomed. This needs careful testing, even if it is a fairly simple change (at least in comparison to other ways of dealing with the problem!)