### PR TITLE
Allow users to set their own tx fees, as suggested in #657

### DIFF
--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -137,9 +137,10 @@ minimum_makers = 2
 # so we choose N=3 for a more reasonable figure,
 # as our default. Note that for clients not using a local blockchain
 # instance, we retrieve an estimate from the API at blockcypher.com, currently.
-# WARNING: Configuring N=1 can have unexpected effects, as bitcoin core
-# sometimes responds with -1 when it can't make a precise fee estimate!
-# Thus, N should almost always be >= 2, unless you know what you're doing.
+# You can also set your own fee/kb: any number higher than 144 will
+# be interpreted as the fee in satoshi per kB that you wish to use
+# example: N=30000 will use 30000 sat/kB as a fee, while N=5
+# will use the estimate from your selected blockchain source
 tx_fees = 3
 # For users getting transaction fee estimates over an API
 # (currently blockcypher, could be others), place a sanity

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -25,7 +25,7 @@ def estimate_tx_fee(ins, outs, txtype='p2pkh'):
     '''
     tx_estimated_bytes = btc.estimate_tx_size(ins, outs, txtype)
     log.debug("Estimated transaction size: "+str(tx_estimated_bytes))
-    fee_per_kb = jm_single().bc_interface.estimate_fee_per_kb(
+    fee_per_kb = jm_single().bc_interface.get_fee(
         jm_single().config.getint("POLICY", "tx_fees"))
     absurd_fee = jm_single().config.getint("POLICY", "absurd_fee_per_kb")
     if fee_per_kb > absurd_fee:


### PR DESCRIPTION
While at it, I also fixed the "don't use N=1 with bitcoin core" (which returns -1 and leads to a hardcoded fee instead of honoring the user's wish to target a REALLY fast confirmation block). It's now handled automatically.