### PR TITLE
Allow execution from any filepath

### DIFF
--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -39,7 +39,8 @@ class AttributeDict(object):
             logFormatter = logging.Formatter(
                 ('%(asctime)s [%(threadName)-12.12s] '
                  '[%(levelname)-5.5s]  %(message)s'))
-            fileHandler = logging.FileHandler('logs/{}.log'.format(value))
+            dirname = os.path.split(os.path.abspath(__file__))
+            fileHandler = logging.FileHandler(os.path.join(dirname[0][:-11], 'logs/{}.log'.format(value)))
             fileHandler.setFormatter(logFormatter)
             log.addHandler(fileHandler)
 

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -147,9 +147,10 @@ class Wallet(AbstractWallet):
             self.index.append([0, 0])
 
     def read_wallet_file_data(self, filename, pwd=None):
+        dirname = os.path.split(os.path.abspath(__file__))
         self.path = None
         self.index_cache = [[0, 0]] * self.max_mix_depth
-        path = os.path.join('wallets', filename)
+        path = os.path.join(dirname[0][:-11], 'wallets', filename)
         if not os.path.isfile(path):
             if get_network() == 'testnet':
                 log.debug('filename interpreted as seed, only available in '

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -270,14 +270,16 @@ elif method == 'dumpprivkey':
 elif method == 'listwallets':
     # Fetch list of wallets
     possible_wallets = []
-    for (dirpath, dirnames, filenames) in os.walk('wallets'):
+    dirname = os.path.split(os.path.abspath(__file__))
+    for (dirpath, dirnames, filenames) in os.walk(os.path.join(dirname[0], 'wallets')):
         possible_wallets.extend(filenames)
         # Breaking as we only want the top dir, not subdirs
         break
     # For each possible wallet file, read json to list
     walletjsons = []
     for possible_wallet in possible_wallets:
-        fd = open(os.path.join('wallets', possible_wallet), 'r')
+        dirname = os.path.split(os.path.abspath(__file__))
+        fd = open(os.path.join(dirname[0], 'wallets', possible_wallet), 'r')
         try:
             walletfile = fd.read()
             walletjson = json.loads(walletfile)


### PR DESCRIPTION
Until now you had to go go into the folder containing wallet-tool, yg or any other of the tools to use them. This commit solves this (at least for wallet-tool, log creation and everywhere the Wallet class is used).

**You can now execute joinmarket from any filepath using a command like this
`python ~/Desktop/JoinmarketDev/yield-generator-basic.py wallet.json`**

I am not sure if I have missed any code where the folder is being assumed.

To figure you the filepath a python function has been used. For all files in the /joinmarket/ subfolder the subfolder name is being stripped using `[:-11]`. Additionally the method to get the filepath returns a tuple and the actual filepath is accessed using the index.

I am not sure if this is best practice, since my knowledge in Python is still limited. Please suggest missing cases and code improvements!

