### PR TITLE
Allow no/empty password (Implements #674)

### DIFF
--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -177,11 +177,16 @@ class Wallet(AbstractWallet):
                 self.index_cache += [[0,0]] * (
                     self.max_mix_depth - len(self.index_cache))
         decrypted = False
+        trieddefault = False
         while not decrypted:
-            if pwd:
-                password = pwd
+            if trieddefault:
+                password = ''
+                trieddefault = True
             else:
-                password = getpass('Enter wallet decryption passphrase: ')
+                if pwd:
+                    password = pwd
+                else:
+                    password = getpass('Enter wallet decryption passphrase: ')
             password_key = btc.bin_dbl_sha256(password)
             encrypted_seed = walletdata['encrypted_seed']
             try:
@@ -196,7 +201,8 @@ class Wallet(AbstractWallet):
                 else:
                     raise ValueError
             except ValueError:
-                print('Incorrect password')
+                if not trieddefault:
+                    print('Incorrect password')
                 if pwd:
                     raise
                 decrypted = False

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -179,7 +179,7 @@ class Wallet(AbstractWallet):
         decrypted = False
         trieddefault = False
         while not decrypted:
-            if trieddefault:
+            if not trieddefault:
                 password = ''
                 trieddefault = True
             else:

--- a/joinmarket/wallet.py
+++ b/joinmarket/wallet.py
@@ -179,14 +179,15 @@ class Wallet(AbstractWallet):
         decrypted = False
         trieddefault = False
         while not decrypted:
-            if not trieddefault:
-                password = ''
-                trieddefault = True
+            if pwd:
+                password = pwd
             else:
-                if pwd:
-                    password = pwd
+                if not trieddefault:
+                    password = ''
+                    trieddefault = True
                 else:
                     password = getpass('Enter wallet decryption passphrase: ')
+
             password_key = btc.bin_dbl_sha256(password)
             encrypted_seed = walletdata['encrypted_seed']
             try:

--- a/test/test_wallets.py
+++ b/test/test_wallets.py
@@ -295,10 +295,18 @@ class TestWalletCreation(unittest.TestCase):
 
     def run_generate(self, pwd):
         try:
-            test_in = [pwd, pwd, 'testwallet.json']
-            expected = ['Enter wallet encryption passphrase:',
-                        'Reenter wallet encryption passphrase:',
-                        'Input wallet file name']
+            if len(pwd):
+                test_in = [pwd, pwd, 'testwallet.json']
+                expected = ['Enter wallet encryption passphrase:',
+                            'Reenter wallet encryption passphrase:',
+                            'Input wallet file name']
+            else:
+                test_in = [pwd, pwd, 'n', 'testwallet.json']
+                expected = ['Enter wallet encryption passphrase:',
+                            'Reenter wallet encryption passphrase:',
+                            'Abort?',
+                            'Input wallet file name']
+
             testlog = open('test/testlog-' + pwd, 'wb')
             p = pexpect.spawn('python wallet-tool.py generate', logfile=testlog)
             interact(p, test_in, expected)

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -191,6 +191,29 @@ if method == 'display' or method == 'displayall' or method == 'summary':
         print('for mixdepth=%d balance=%.8fbtc' % (m, balance_depth / 1e8))
     print('total balance = %.8fbtc' % (total_balance / 1e8))
 elif method == 'generate' or method == 'recover':
+
+    def query_yes_no(question, default="yes"):
+        valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
+        if default is None:
+            prompt = " [y/n] "
+        elif default == "yes":
+            prompt = " [Y/n] "
+        elif default == "no":
+            prompt = " [y/N] "
+        else:
+            raise ValueError("invalid default answer: '%s'" % default)
+
+        while True:
+            sys.stdout.write(question + prompt)
+            choice = raw_input().lower()
+            if default is not None and choice == '':
+                return valid[default]
+            elif choice in valid:
+                return valid[choice]
+            else:
+                sys.stdout.write("Please respond with 'yes' or 'no' "
+                       "(or 'y' or 'n').\n")
+
     if method == 'generate':
         seed = btc.sha256(os.urandom(64))[:32]
         words = mn_encode(seed)
@@ -209,6 +232,13 @@ elif method == 'generate' or method == 'recover':
     if password != password2:
         print('ERROR. Passwords did not match')
         sys.exit(0)
+    if password == "":
+        print('============= WARNING =============')
+        print('Using no password is very dangerous')
+        print('===================================')
+        abort = query_yes_no('Abort?')
+        if abort:
+            sys.exit(0)
     password_key = btc.bin_dbl_sha256(password)
     encrypted_seed = encryptData(password_key, seed.decode('hex'))
     timestamp = datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")


### PR DESCRIPTION
**This allows wallets to have a zero length (`''`) password. (As requested in #674)**

When generating a new wallet and pressing enter both times when you are asked to set a password it will present you with the following warning
```
============= WARNING =============
Using no password is very dangerous
===================================
Abort? [Y/n]
```
To proceed with a empty password you have to confirm with a `n`, pressing enter will stop the generation process.

The wallet checks `''` and if it does not unlock the wallet it will ask the user to input the password.