### PR TITLE
Increments default walletname when wallet already exists

### DIFF
--- a/test/test_wallets.py
+++ b/test/test_wallets.py
@@ -244,6 +244,47 @@ def test_change_passphrase(setup_wallets, pwd, new_pwd, expected_output):
     p.close()
     testlog.close()
 
+def test_multiple_default_wallets(mainnet=True):
+    """ This creates three wallets in succession without naming them. creates
+    wallet.json, wallet1.json, wallet2.json etc.
+    """
+# Wasn't sure if it was a good idea to check and remove before starting,
+# probably not
+# I wouldn't want someone to run tests and then delete their wallets
+# unknowingly
+#   try:
+#       os.remove("wallets/wallet.json")
+#       os.remove("wallets/wallet.json")
+#       os.remove("wallets/wallet.json")
+#   except:
+#       pass
+
+    pwd = 'import-pwd'
+    test_in = [pwd, pwd, '']
+    expected = ['Enter wallet encryption passphrase:',
+                'Reenter wallet encryption passphrase:',
+                'Input wallet file name']
+    testlog = open('test/testlog-generate-multiple-default-wallets', 'wb')
+
+    test_in = [pwd, pwd, '']
+    p = pexpect.spawn('python wallet-tool.py generate', logfile=testlog)
+    interact(p, test_in, expected)
+    p.expect('saved to')
+    time.sleep(1)
+
+    p = pexpect.spawn('python wallet-tool.py generate', logfile=testlog)
+    interact(p, test_in, expected)
+    p.expect('saved to')
+    time.sleep(1)
+
+    p = pexpect.spawn('python wallet-tool.py generate', logfile=testlog)
+    interact(p, test_in, expected)
+    p.expect('saved to')
+    time.sleep(1)
+
+    p.close()
+    testlog.close()
+
 
 def setup_import(mainnet=True):
     try:

--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -227,9 +227,21 @@ elif method == 'generate' or method == 'recover':
                              'creation_time': timestamp,
                              'encrypted_seed': encrypted_seed.encode('hex'),
                              'network': get_network()})
-    walletname = raw_input('Input wallet file name (default: wallet.json): ')
+
+    default_walletname = 'wallet.json'
+    walletpath = os.path.join('wallets', default_walletname)
+    input_greeting = 'Input wallet file name (default: wallet.json): '
+    i = 1
+    while os.path.isfile(walletpath):
+        temp_walletname = default_walletname
+        default_walletname = 'wallet{0}.json'.format(i)
+        walletpath = os.path.join('wallets', default_walletname)
+        input_greeting = input_greeting.replace(temp_walletname, default_walletname)
+        i += 1
+
+    walletname = raw_input(input_greeting)
     if len(walletname) == 0:
-        walletname = 'wallet.json'
+        walletname = default_walletname
     walletpath = os.path.join('wallets', walletname)
     # Does a wallet with the same name exist?
     if os.path.isfile(walletpath):


### PR DESCRIPTION
Allows multiple:
`python wallet-tool.py generate`

 wallet.json increments to wallet<#>.json checking if available first.
wallet.json wallet1.json etc.
Tests included generating three wallets with default names.
closes #678 