### PR TITLE
Change user agent to Firefox ESR for improved privacy

### DIFF
--- a/bitcoin/bci.py
+++ b/bitcoin/bci.py
@@ -25,7 +25,7 @@ def make_request(*args):
     else:
         opener = build_opener()
     opener.addheaders = [('User-agent',
-                          'Mozilla/5.0' + str(random.randrange(1000000)))]
+                          'Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0')]
     try:
         return opener.open(*args).read().strip()
     except Exception as e:


### PR DESCRIPTION
Change user agent to Firefox ESR for improved privacy

Currently user agent is set to a string that (in practice) identifies a request as being from JoinMarket. This is bad for privacy.

This PR changes the user agent to a standard Firefox ESR user agent string. This is what is used by Tor Browser and will help JoinMarket requests blend in more. New ESR releases are made once a year so this will not need to be changed often.