### PR TITLE
Switch blockr to electrum as default blockchain interface

### DIFF
--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -84,7 +84,7 @@ required_options = {'BLOCKCHAIN': ['blockchain_source', 'network'],
 defaultconfig = \
     """
 [BLOCKCHAIN]
-blockchain_source = blockr
+blockchain_source = electrum
 #options: blockr, bitcoin-rpc, regtest, bc.i, electrum
 # for instructions on bitcoin-rpc read
 # https://github.com/chris-belcher/joinmarket/wiki/Running-JoinMarket-with-Bitcoin-Core-full-node


### PR DESCRIPTION
Rationale:
blockr as default does not work for TAILS and other TOR users any more. This will reduce potential confusion, while at the same time not reducing privacy (blockr potentially has worse privacy implications, electrum is at least somewhat decentralized).