### PR TITLE
lock db access from taker scripts to avoid cursor exceptions

### DIFF
--- a/sendpayment.py
+++ b/sendpayment.py
@@ -101,8 +101,9 @@ class PaymentThread(threading.Thread):
         self.ignored_makers = []
 
     def create_tx(self):
-        crow = self.taker.db.execute(
-            'SELECT COUNT(DISTINCT counterparty) FROM orderbook;').fetchone()
+        with self.taker.dblock:
+            crow = self.taker.db.execute(
+                'SELECT COUNT(DISTINCT counterparty) FROM orderbook;').fetchone()
         counterparty_count = crow['COUNT(DISTINCT counterparty)']
         counterparty_count -= len(self.ignored_makers)
         if counterparty_count < self.taker.makercount:

--- a/tumbler.py
+++ b/tumbler.py
@@ -341,8 +341,8 @@ class TumblerThread(threading.Thread):
     def run(self):
         log.info('waiting for all orders to certainly arrive')
         time.sleep(self.taker.options['waittime'])
-
-        sqlorders = self.taker.db.execute(
+        with self.taker.dblock:
+            sqlorders = self.taker.db.execute(
                 'SELECT cjfee, ordertype FROM orderbook;').fetchall()
         orders = [o['cjfee'] for o in sqlorders if o['ordertype'] == 'reloffer']
         orders = sorted(orders)


### PR DESCRIPTION
See #707 and my comment on it for explanation.

Testing: I'm finding it very difficult to reproduce, I believe this is because it fundamentally depends on the speed with which the db call returns; even with 6 makers x 300 orders each (done by slight tweaks to scripts and running ygrunner/sendpayment) I was only able to reproduce the "Recursive use of cursor" exception once, so not reliably, at least yet.

On the other hand, the test suite passes, so in the case that this *doesn't* solve the observed problem in the live pit (well, I hope it does), I don't see it causing a problem.