### PR TITLE
For CJs: ignore makers with overlapping offer ranges

### DIFF
--- a/joinmarket/support.py
+++ b/joinmarket/support.py
@@ -319,6 +319,7 @@ def choose_sweep_orders(db,
 
     if ignored_makers is None:
         ignored_makers = []
+    remove_invalid_makers_from_db(db)
 
     def calc_zero_change_cj_amount(ordercombo):
         sumabsfee = 0


### PR DESCRIPTION
support.py: checkes if makers have overlapping offers and removes them from being considered for joins

This is done efficiently in O(n) by adding up the ranges of a maker's offers.
Example:
Maker has 3 offers:
a) min=1, max=3
b) min=1.5, max=4
c) min=3, max=5

First, the "total" maximum range of that maker is highest_max - lowest_min (in this case: 5-1=4).
Now the single ranges are iteratively added up and checked against the "total" max.

 If there is no overlap, then the total max will always be >= the added up ranges of the individual offers.

Currently, about 25% of all makers use overlapping ranges and would be filtered out by this.