### PR TITLE
fixed absurd miner fee check

### DIFF
--- a/joinmarket/configure.py
+++ b/joinmarket/configure.py
@@ -147,7 +147,7 @@ tx_fees = 3
 # check limit on the satoshis-per-kB to be paid. This limit
 # is also applied to users using Core, even though Core has its
 # own sanity check limit, which is currently 1,000,000 satoshis.
-absurd_fee_per_kb = 150000
+absurd_fee_per_kb = 2000000
 # the range of confirmations passed to the `listunspent` bitcoind RPC call
 # 1st value is the inclusive minimum, defaults to one confirmation
 # 2nd value is the exclusive maximum, defaults to most-positive-bignum (Google Me!)

--- a/test/test_blockr.py
+++ b/test/test_blockr.py
@@ -38,6 +38,7 @@ def test_bci_bad_pushtx():
             btc.bci_pushtx(i[0])
 
 def test_blockr_estimate_fee(setup_blockr):
+    absurd_fee = jm_single().config.getint("POLICY", "absurd_fee_per_kb")
     res = []
     for N in [1,3,6]:
         res.append(jm_single().bc_interface.estimate_fee_per_kb(N))
@@ -45,8 +46,8 @@ def test_blockr_estimate_fee(setup_blockr):
     #Note this can fail, it isn't very accurate.
     #assert res[1] >= res[2]
     #sanity checks:
-    assert res[0] < 200000
-    assert res[2] < 150000
+    assert res[0] < absurd_fee
+    assert res[2] < absurd_fee
 
 @pytest.mark.parametrize(
     "net, seed, gaplimit, showprivkey, method",


### PR DESCRIPTION
What we previously thought was an absurd miner fee is now the reality.

Bumped up this absurd value to be an order of magnitude higher than the current market fee rate.

Also fixed the test which had hard-coded absurd values, it now uses the absurd values from the joinmarket.cfg file. This is breaking all automated test runs right now. See https://travis-ci.org/JoinMarket-Org/joinmarket/builds/207548542#L1336