### PR TITLE
Import privkey non-interactively

### DIFF
--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -295,7 +295,11 @@ elif method == 'importprivkey':
     print('WARNING: Handling of raw ECDSA bitcoin private keys can lead to '
           'non-intuitive behaviour and loss of funds.\n  Recommended instead '
           'is to use the \'sweep\' feature of sendpayment.py ')
-    privkeys = raw_input('Enter private key(s) to import: ')
+    if len(args) > 3 and args[2] == \
+            'cli-import-WARNING-DANGEROUS-DONT-USE-WITHOUT-UNDERSTANDING':
+        privkeys = args[3]
+    else:
+        privkeys = raw_input('Enter private key(s) to import: ')
     privkeys = privkeys.split(',') if ',' in privkeys else privkeys.split()
     # TODO read also one key for each line
     for privkey in privkeys:


### PR DESCRIPTION
This feature was requested and it's quick to code so here it is. Intended for automated scripts, people should still use the old method.

`python wallet-tool.py wallet.json importprivkey cli-import-WARNING-DANGEROUS-DONT-USE-WITHOUT-UNDERSTANDING your-private-key-here`

I tested this by importing testnet keys with the old and new method.

I'll also add a how-to for this on the relevant section in the wiki, as well as explaining the danger of how it makes your private key end up in `.bash_history`