### PR TITLE
Add "extend_mixdepth=True" to yieldgen

### DIFF
--- a/joinmarket/yieldgenerator.py
+++ b/joinmarket/yieldgenerator.py
@@ -145,7 +145,7 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
         if ret[0] != 'y':
             return
 
-    wallet = Wallet(seed, max_mix_depth=MAX_MIX_DEPTH, gaplimit=gaplimit)
+    wallet = Wallet(seed, max_mix_depth=MAX_MIX_DEPTH, gaplimit=gaplimit, extend_mixdepth=True)
     sync_wallet(wallet, fast=options.fastsync)
 
     mcs = [IRCMessageChannel(c, realname='btcint=' + jm_single().config.get(


### PR DESCRIPTION
I have an old wallet that has more than the default mix depths. I don't want to spend the transaction fees to move all the coins out of my mix depths over the default.  wallet-tool is smart about expanding the max, but whenever my yield generator updates the wallet, it cuts off any index_cache above the default.

I had a moment of panic where I thought coins were missing until I looked and saw it was only counting the first 5 depths.

This should keep everyone on 5 but keep old wallets working fine.