### PR TITLE
fix scrub-log.py bug: also scrub unicode TXIDs

### DIFF
--- a/logs/scrub-log.py
+++ b/logs/scrub-log.py
@@ -50,7 +50,7 @@ patterns = [
     ('(\W)([0-9a-fA-F]{64}):(\d+)(\W)',
     lambda m: m.group(1) + 'TXID_INDEX_%056d' + m.group(4),
     'txid:index'),
-    ('(gettxout \\[\')([0-9a-fA-F]{64}\', \d+)(, (True|False)\\])',
+    ('(gettxout \\[u?\')([0-9a-fA-F]{64}\', \d+)(, (True|False)\\])',
     lambda m: m.group(1) + 'TXID_%059d\', IDX_%03d' +  m.group(3),
     'gettxout'),
     ('(\'value\': )(\d+)(\\})',


### PR DESCRIPTION
The scrub-log.py script failed to delete TXIDs that got dribbled into the log as unicode. Why this happens is not yet fully clear, but it appears to only occur with the `gettxout` RPC call. Problem was spotted by @AdamISZ while [helping a redditor](https://www.reddit.com/r/joinmarket/comments/6oyx3n/strange_maker_logs_not_sure_how_to_explain_at/).