### PR TITLE
Update requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ pytest==2.8.2
 pytest-cov==2.2.1
 python-coveralls
 mock
+testscenarios
 
 -r requirements.txt


### PR DESCRIPTION
tests would fail with error like:

CalledProcessError: Command '['/Users/carlcrott/Documents/python_projects/bitcoin/src/bitcoin-cli', '-regtest', '-rpcuser=bitcoinrpc', '-rpcpassword=asdf', 'generate', '101']' returned non-zero exit status 1

adding this fixes the error + allows tests to complete